### PR TITLE
WOK-361: set initial search term from param in created() hook

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -30,12 +30,15 @@ export default defineComponent({
 		return { searchResultStore };
 	},
 	created() {
-		// Watch query params and update search results if anything changes 
+		// Set initial search term from query param
+		this.searchResultStore.getSearchResults(this.$route.query.term as string);
+
+		// Watch the 'term' param and update search results if it changes
 		this.$watch(
 			() => this.$route.query.term,
 			(newTerm: string, prevTerm: string) => {
 				if (newTerm !== prevTerm) {
-					this.searchResultStore.getSearchResults(newTerm as string);
+					this.searchResultStore.getSearchResults(newTerm);
 				}
 			},
 		);
@@ -47,10 +50,6 @@ export default defineComponent({
 temporary styling until patterns from design system are implemented 
 -->
 <style scoped>
-.search-box {
-	width: 100%;
-}
-
 .hit-count {
 	text-align: left;
 	padding: 0 200px 0 200px;


### PR DESCRIPTION
This fixes an issue where search wouldn't trigger when first loading the component. The problem was resolved by adding an initial search term in the created() lifecycle hook.