### PR TITLE
Move result data from observed attribute to property in web component

### DIFF
--- a/src/components/nav/menu-component.ts
+++ b/src/components/nav/menu-component.ts
@@ -83,7 +83,7 @@ class MenuComponent extends HTMLElement {
 		}
 	}
 
-	createSingleMenu(parent: HTMLElement, menu: Array<TranslationItem>, name: string) {
+	createSingleMenu(parent: HTMLElement, menu: Array<MenuTranslationItem>, name: string) {
 		const currentMenu = document.createElement('ul');
 		currentMenu.setAttribute('role', 'menubar');
 		currentMenu.classList.add(name);

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -7,7 +7,7 @@
 		<kb-resultcomponent
 			:vueRouting="true"
 			:number="index"
-			:data="JSON.stringify(res)"
+			:resultData="res"
 			:show="showResults"
 		/>
 	</div>

--- a/src/components/search/result-component.ts
+++ b/src/components/search/result-component.ts
@@ -1,7 +1,11 @@
+import { GenericSearchResult } from '@/types/GenericSearchResult';
+
 class ResultComponent extends HTMLElement {
 	shadow: ShadowRoot;
 	number: number | undefined;
 	vueRouting: boolean | undefined;
+	resultData: GenericSearchResult | undefined;
+
 	constructor() {
 		super();
 		this.shadow = this.attachShadow({ mode: 'open' });
@@ -28,47 +32,54 @@ class ResultComponent extends HTMLElement {
 	}
 
 	static get observedAttributes() {
-		return ['data', 'number', 'show', 'vueRouting'];
+		return ['number', 'show', 'vueRouting'];
 	}
 
 	showImage() {
 		this.style.opacity = '1';
 	}
 
-	attributeChangedCallback(name: string, oldValue: string, newValue: string) {
-		if (name === 'data') {
-			const resultData = JSON.parse(newValue);
-			const title = this.shadow.querySelector('.title') as HTMLAnchorElement;
-			title && (title.href = 'record/' + resultData.id); // /record/:id
-			title.addEventListener('click', (event) => {
-				if (this.vueRouting) {
-					event.preventDefault();
-					window.dispatchEvent(
-						new CustomEvent('change-path', {
-							detail: { path: 'record/' + resultData.id },
-						}),
-					);
-				}
-			});
-			title && (title.textContent = resultData.title);
-
-			const where = this.shadow.querySelector('.where');
-			where && (where.textContent = 'KANAL');
-
-			const when = this.shadow.querySelector('.when');
-			when && (when.textContent = 'TIDSPUNKT');
-
-			const duration = this.shadow.querySelector('.duration');
-			duration && (duration.textContent = 'VARIGHED');
-
-			const thumb = this.shadow.querySelector('.image-item') as HTMLImageElement;
-			thumb && (thumb.src = resultData.thumbnail);
-
-			const summary = this.shadow.querySelector('.summary');
-			summary &&
-				(summary.textContent =
-					'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam tristique nibh vel consectetur condimentum. Vestibulum dictum luctus nulla, eu aliquam arcu vehicula eget. Praesent tristique, tortor a posuere faucibus, urna odio aliquet massa, sit amet viverra eros magna et sapien. Suspendisse sodales porta erat, nec fermentum nisi.');
+	connectedCallback() {
+		if (this.resultData) {
+			this.renderResultData(this.resultData);
 		}
+	}
+
+	renderResultData(resultData: GenericSearchResult) {
+		const title = this.shadow.querySelector('.title') as HTMLAnchorElement;
+		title && (title.href = 'record/' + resultData.id);
+		title.addEventListener('click', (event) => {
+			if (this.vueRouting) {
+				event.preventDefault();
+				window.dispatchEvent(
+					new CustomEvent('change-path', {
+						detail: { path: 'record/' + resultData.id },
+					}),
+				);
+			}
+		});
+
+		title && (title.textContent = resultData.title);
+
+		const where = this.shadow.querySelector('.where');
+		where && (where.textContent = 'KANAL');
+
+		const when = this.shadow.querySelector('.when');
+		when && (when.textContent = 'TIDSPUNKT');
+
+		const duration = this.shadow.querySelector('.duration');
+		duration && (duration.textContent = 'VARIGHED');
+
+		const thumb = this.shadow.querySelector('.image-item') as HTMLImageElement;
+		thumb && (thumb.src = resultData.thumbnail);
+
+		const summary = this.shadow.querySelector('.summary');
+		summary &&
+			(summary.textContent =
+				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam tristique nibh vel consectetur condimentum. Vestibulum dictum luctus nulla, eu aliquam arcu vehicula eget. Praesent tristique, tortor a posuere faucibus, urna odio aliquet massa, sit amet viverra eros magna et sapien. Suspendisse sodales porta erat, nec fermentum nisi.');
+	}
+
+	attributeChangedCallback(name: string, oldValue: string, newValue: string) {
 		if (name === 'number') {
 			const number = this.shadow.querySelector('number');
 			this.number = Number(newValue);


### PR DESCRIPTION
So another deep dive into the docs of Vue3 and web components. This is the first draft on how we can do this without the heavy use of observables (when not needed). I have passed the complex search result data as a property, declared it is a property in the web component and then made use of the standard connectedCallback to render the results. This approach seems to work and reduce the "observer load"

Learnings when reading through the docs:
 - we should not in (nearly) any case pass complex data as attributes (only simple data). Complex data should be passed as a property and it turns out if your do that _and_ you have declared the property in the web component Vue 3 uses the 'in' operator to check for the presence of DOM properties and prefers to set the value as a DOM property if the key is present - pure magic! This will work most of the time but there are some exceptions (hopefully we will know when we meet them :) )

Take a look at it and if you like what you see I will adapt to this approach going forward (and refactor) :))