### PR TITLE
Persist locale in url after locale switch

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -27,4 +27,11 @@ const router = createRouter({
 	routes,
 });
 
+router.beforeEach((to, from) => {
+	if (from.query.locale && !to.query.locale) {
+		to.query.locale = from.query.locale;
+		return to;
+	}
+});
+
 export default router;


### PR DESCRIPTION
Locale should now be persisted in URL after first locale switch.

On init we rely on the value stored in localstorage (if any) otherwise we default to 'da'.