### PR TITLE
Reworked the way we search

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -133,7 +133,7 @@ export default defineComponent({
 			} else {
 				transitionName.value = 'swipe';
 			}
-			console.log(transitionName.value, ' IT IS');
+			console.log(transitionName.value, 'transition');
 		});
 
 		onMounted(async () => {

--- a/src/api/api-client.ts
+++ b/src/api/api-client.ts
@@ -27,15 +27,8 @@ export class APIServiceClient {
 	}
 
 	//Search and record methods
-	async getSearchResults(query: string, filters: string[]): Promise<APISearchResponseType> {
-		let reqFilters = '';
-		//Temporary fix for filters containing &. We should rework the filter flow so prep of data is done else where DISC-390
-		filters.forEach((filt: string) => {
-			reqFilters += `&fq=${encodeURIComponent(filt.split('fq=')[1])}`;
-		});
-		return await this.httpClient.get(
-			`search/?q=${encodeURIComponent(query)}&q.op=OR&indent=true&facet=true${reqFilters}`,
-		);
+	async getSearchResults(query: string, filters: string): Promise<APISearchResponseType> {
+		return await this.httpClient.get(`search/?q=${encodeURIComponent(query)}&q.op=OR&indent=true&facet=true${filters}`);
 	}
 
 	async getRecord(id: string): Promise<APIRecordResponseType> {

--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -79,7 +79,8 @@ export default defineComponent({
 		});
 
 		const filterExists = (key: string, title: string) => {
-			return searchResultStore.filters.includes(`fq=${key}:"${title}"`);
+			const filterString = `${key}:"${title}"`;
+			return searchResultStore.filters.includes(`fq=${encodeURIComponent(filterString)}`);
 		};
 
 		const filterUpdateHelper = (e: Event) => {
@@ -108,14 +109,16 @@ export default defineComponent({
 					//This will only trigger if someone manipulates the url manually
 					routeQueries.fq = [routeQueries.fq, newFilter];
 				}
-				searchResultStore.addFilter(`fq=${e.detail.filter}`);
 			} else {
+				// if there's more than one, it's an array. If there's just one, it a string (apparently), that we can just remove.
 				const filterToRemove = encodeURIComponent(e.detail.filter);
-				routeQueries.fq = routeQueries.fq.filter((item: string) => item !== filterToRemove);
-				searchResultStore.removeFilter(`fq=${e.detail.filter}`);
+				if (Array.isArray(routeQueries.fq)) {
+					routeQueries.fq = routeQueries.fq.filter((item: string) => item !== filterToRemove);
+				} else {
+					routeQueries.fq = undefined;
+				}
 			}
 			router.push({ query: routeQueries });
-			searchResultStore.getSearchResults(searchResultStore.currentQuery);
 		};
 		// A simple method to arrange the facets in an orderly fasion, so they're easier to loop through.
 		// Might not be relevant when we know more about the backend structure.

--- a/src/components/search/SearchBarWrapper.vue
+++ b/src/components/search/SearchBarWrapper.vue
@@ -28,7 +28,6 @@ export default defineComponent({
 		const xReset = ref(false);
 
 		onMounted(() => {
-			console.log(searchResultStore.searchFired);
 			if (searchResultStore.searchFired) {
 				xReset.value = true;
 			}

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -50,7 +50,7 @@ export default defineComponent({
 			watch(
 				() => props.searchResults,
 				(newResults: GenericSearchResultType[], prevResults: GenericSearchResultType[]) => {
-					console.log('new results!', newResults, prevResults);
+					console.log('results updated because of the watcher in searchResults.vue');
 					if (newResults !== prevResults) {
 						showResults.value = false;
 						setTimeout(

--- a/src/components/search/wc-searchbar.ts
+++ b/src/components/search/wc-searchbar.ts
@@ -52,7 +52,6 @@ class SearchBarComponent extends HTMLElement {
 	}
 
 	attributeChangedCallback(name: string, oldValue: string, newValue: string) {
-		console.log('YEARP', name, newValue);
 		if (name === 'reset-value') {
 			this.showXButton = JSON.parse(newValue.toLowerCase());
 			this.setResetVisibility(this.showXButton);

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -158,12 +158,9 @@ export default defineComponent({
 				if (routeFacetQueries) {
 					searchResultStore.setFiltersFromURL(routeFacetQueries);
 				}
+				searchResultStore.getSearchResults(route.query.q as string);
 			}
 		});
-
-		if (route.query.q !== undefined) {
-			searchResultStore.getSearchResults(route.query.q as string);
-		}
 
 		/* This is because Vue3 composition API has this weird bug that when a ref is wrapped in a v-if
 		   the ref is not actually present in onMounted, which is super weird. But we can watch for when it enters.
@@ -194,25 +191,21 @@ export default defineComponent({
 			() => router.currentRoute.value,
 			(newp: RouteLocationNormalizedLoaded, prevp: RouteLocationNormalizedLoaded) => {
 				console.log('watcher in search found a change in the URL, so we do a check if we should search.');
-				if (checkParamUpdate(newp, prevp) && router.currentRoute.value.query.q !== undefined) {
-					searchResultStore.setFiltersFromURL(router.currentRoute.value.query.fq as string[]);
-					searchResultStore.getSearchResults(router.currentRoute.value.query.q as string);
+				if (checkParamUpdate(newp, prevp) && route.query.q !== undefined) {
+					searchResultStore.setFiltersFromURL(route.query.fq as string[]);
+					searchResultStore.getSearchResults(route.query.fq as string);
 				}
-				if (router.currentRoute.value.query.q === undefined) {
+				if (route.query.q === undefined) {
 					searchResultStore.resetSearch();
 				}
 			},
 		);
 
 		const checkParamUpdate = (newParams: RouteLocationNormalizedLoaded, prevParams: RouteLocationNormalizedLoaded) => {
-			if (
+			return (
 				newParams.query.q !== prevParams.query.q ||
 				JSON.stringify(newParams.query.fq) !== JSON.stringify(prevParams.query.fq)
-			) {
-				return true;
-			} else {
-				return false;
-			}
+			);
 		};
 
 		const updateFacetContainer = () => {

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -193,7 +193,7 @@ export default defineComponent({
 				console.log('watcher in search found a change in the URL, so we do a check if we should search.');
 				if (checkParamUpdate(newp, prevp) && route.query.q !== undefined) {
 					searchResultStore.setFiltersFromURL(route.query.fq as string[]);
-					searchResultStore.getSearchResults(route.query.fq as string);
+					searchResultStore.getSearchResults(route.query.q as string);
 				}
 				if (route.query.q === undefined) {
 					searchResultStore.resetSearch();


### PR DESCRIPTION
So, this is a little bit of a major overhaul of the way we search. I've reworked it as such:

Everything is now handled by the URL - and a single watcher in the Search.vue file. This was to ensure that we don't fire of searches from other places (ie facets or some other place).

In the search watcher, we look at what has changed - this should be further elaborated to also include the offset / start params when we add the pagination. But the good thing is, thats all we gotta do. Just update the URL and the watcher handles the rest with a new query. (we probably need to add the offset/start to the query aswell, but that shouldn't be too hard)

I've left in some console.logs - I think it's okey they're there for now so we can look at what's going on (if something starts to not work as intended)

I also moved the filter logic away from the api-client function to a better place, imho.

The searchResultStore has also been expanded to handle some of the responsibility on the filters. I think that's a decent way to do it - but happy to discuss other options.