### PR TITLE
DISC-437/add-time-on-search-results

### DIFF
--- a/src/components/common/Duration.vue
+++ b/src/components/common/Duration.vue
@@ -5,6 +5,7 @@
 <script lang="ts">
 import { defineComponent, PropType, ref, onMounted, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { formatDuration } from '@/utils/time-utils';
 
 export default defineComponent({
 	name: 'Duration',
@@ -26,72 +27,13 @@ export default defineComponent({
 		const formattedDuration = ref('');
 		const { locale, t } = useI18n();
 
-		const calculateDuration = (startDate: string, endDate: string) => {
-			const startDateObj = new Date(startDate);
-			const endDateObj = new Date(endDate);
-
-			const isStartDateValid = startDate && !isNaN(startDateObj.getTime());
-			const isEndDateValid = endDate && !isNaN(endDateObj.getTime());
-
-			if (isStartDateValid && isEndDateValid) {
-				const duration = endDateObj.getTime() - startDateObj.getTime();
-
-				if (!isNaN(duration)) {
-					const hours = Math.floor(duration / 3600000);
-					const minutes = Math.floor((duration % 3600000) / 60000);
-					const seconds = Math.floor((duration % 60000) / 1000);
-					const durationParts = generateDurationParts(hours, minutes, seconds);
-					formattedDuration.value = durationParts.join(' ');
-					return;
-				}
-			}
-			formattedDuration.value = t('duration.unknown');
-		};
-
-		const formatDuration = () => {
-			const isoDuration = props.isoDuration;
-			const startDate = props.startDate;
-			const endDate = props.endDate;
-
-			if (isoDuration && isoDuration !== '') {
-				const match = isoDuration.match(/PT(\d+H)?(\d+M)?(\d+S)?/);
-				if (match) {
-					const hours = parseInt(match[1] || '0');
-					const minutes = parseInt(match[2] || '0');
-					const seconds = parseInt(match[3] || '0');
-					const durationParts = generateDurationParts(hours, minutes, seconds);
-					formattedDuration.value = durationParts.join(' ');
-				} else {
-					//If the matcher does not come through - do manual calc
-					calculateDuration(startDate, endDate);
-				}
-			} else if (startDate && endDate) {
-				//If there is no duration at all or it is empty - do manual calc
-				calculateDuration(startDate, endDate);
-			} else {
-				formattedDuration.value = t('duration.unknown');
-			}
-		};
-
-		const generateDurationParts = (hours: number, minutes: number, seconds: number) => {
-			const durationParts: string[] = [];
-			if (hours > 0) {
-				durationParts.push(`${hours}${t('duration.hours')}`);
-			}
-			if (minutes > 0) {
-				durationParts.push(`${minutes}${t('duration.minutes')}`);
-			}
-			if (seconds > 0) {
-				durationParts.push(`${seconds}${t('duration.seconds')}`);
-			}
-			return durationParts;
-		};
-
 		watch(locale, () => {
-			formatDuration();
+			formattedDuration.value = formatDuration(props.isoDuration, props.startDate, props.endDate, t);
 		});
 
-		onMounted(formatDuration);
+		onMounted(() => {
+			formattedDuration.value = formatDuration(props.isoDuration, props.startDate, props.endDate, t);
+		});
 
 		return {
 			formattedDuration,

--- a/src/components/records/BroadcastRecord.vue
+++ b/src/components/records/BroadcastRecord.vue
@@ -13,7 +13,7 @@
 					<h3>Sendt</h3>
 					<div>
 						<span class="material-icons blue">event</span>
-						{{ getBroadcastDate(recordData.startTime) }}
+						{{ getBroadcastDate(recordData.startTime, locale) }}
 					</div>
 					<div>
 						<span class="material-icons blue">schedule</span>
@@ -89,27 +89,20 @@ Mauris non ligula a urna dapibus egestas eget at sem. Sed ac nulla ex. Cras quis
 <script lang="ts">
 import { BroadcastRecordType } from '@/types/BroadcastRecordType';
 import { GenericSearchResultType } from '@/types/GenericSearchResultTypes';
-import { defineComponent, PropType } from 'vue';
+import { defineComponent, onMounted, PropType, ref } from 'vue';
 import VideoPlayer from '@/components/viewers/AudioVideo/video/VideoJsPlayer.vue';
 import Duration from '@/components/common/Duration.vue';
 import GridDisplay from '@/components/common/GridDisplay.vue';
 import { copyTextToClipboard } from '@/utils/copy-script';
+import { getBroadcastDate, getBroadcastTime } from '@/utils/time-utils';
+import { useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 
 import '@/components/common/wc-accordian';
 import '@/components/common/wc-spot-item';
 
 export default defineComponent({
 	name: 'BroadcastRecord',
-	data() {
-		return {
-			lastPath: null as null | string,
-		};
-	},
-	components: {
-		VideoPlayer,
-		Duration,
-		GridDisplay,
-	},
 	props: {
 		recordData: {
 			type: Object as PropType<BroadcastRecordType>,
@@ -120,38 +113,25 @@ export default defineComponent({
 			required: false,
 		},
 	},
-	created() {
-		this.lastPath = this.$router.options.history.state.back as string;
+	components: {
+		VideoPlayer,
+		Duration,
+		GridDisplay,
 	},
-	methods: {
-		getCurrentUrl() {
+	setup() {
+		const lastPath = ref('');
+		const router = useRouter();
+		const { locale } = useI18n();
+
+		onMounted(() => {
+			lastPath.value = router.options.history.state.back as string;
+		});
+
+		const getCurrentUrl = () => {
 			copyTextToClipboard();
-		},
+		};
 
-		getBroadcastDate: (isoDate: string) => {
-			const date = new Date(isoDate);
-
-			// Define formatting options - had to do the weird const typing...
-			const options = {
-				year: 'numeric' as const,
-				month: 'long' as const,
-				day: 'numeric' as const,
-			};
-
-			return new Intl.DateTimeFormat('da-DK', options).format(date);
-		},
-		getBroadcastTime: (isoDate: string) => {
-			const dateObj = new Date(isoDate);
-
-			// Formatting options - had to do the weird const typing...
-			const options = {
-				hour: '2-digit' as const,
-				minute: '2-digit' as const,
-				hour12: false as const,
-			};
-
-			return new Intl.DateTimeFormat('en-GB', options).format(dateObj);
-		},
+		return { lastPath, locale, getCurrentUrl, getBroadcastDate, getBroadcastTime };
 	},
 });
 </script>

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -10,6 +10,16 @@
 			:resultData="res"
 			:show="showResults"
 			:placeholder="getPlaceholderImage()"
+			:duration="
+				locale === 'da'
+					? t('record.duration') + ': ' + formatDuration(res.duration, res.startTime, res.endTime, t)
+					: t('record.duration') + ': ' + formatDuration(res.duration, res.startTime, res.endTime, t)
+			"
+			:starttime="
+				res.startTime
+					? getBroadcastDate(res.startTime, locale) + ' ' + t('record.timestamp') + getBroadcastTime(res.startTime)
+					: t('record.noBoardcastData')
+			"
 		/>
 	</div>
 </template>
@@ -17,6 +27,8 @@
 <script lang="ts">
 import { defineComponent, PropType, ref, watch, onMounted, toRaw } from 'vue';
 import { GenericSearchResultType } from '@/types/GenericSearchResultTypes';
+import { formatDuration, getBroadcastDate, getBroadcastTime } from '@/utils/time-utils';
+import { useI18n } from 'vue-i18n';
 
 import '@/components/search/wc-result-item';
 
@@ -28,6 +40,7 @@ export default defineComponent({
 	},
 
 	setup(props) {
+		const { t, locale } = useI18n();
 		const showResults = ref(false);
 		const currentResults = ref([] as GenericSearchResultType[]);
 		const lastUpdate = ref(0);
@@ -67,11 +80,16 @@ export default defineComponent({
 		});
 
 		return {
+			formatDuration,
+			getBroadcastDate,
+			getBroadcastTime,
 			getPlaceholderImage,
 			getAltTxt,
 			showResults,
 			currentResults,
 			lastUpdate,
+			t,
+			locale,
 		};
 	},
 });

--- a/src/components/search/wc-result-item.ts
+++ b/src/components/search/wc-result-item.ts
@@ -30,7 +30,7 @@ class ResultComponent extends HTMLElement {
 	}
 
 	static get observedAttributes() {
-		return ['number', 'show', 'vueRouting'];
+		return ['show', 'duration', 'starttime'];
 	}
 
 	connectedCallback() {
@@ -56,13 +56,9 @@ class ResultComponent extends HTMLElement {
 		title && (title.textContent = resultData.title);
 
 		const where = this.shadow.querySelector('.where');
-		where && (where.textContent = 'KANAL');
-
-		const when = this.shadow.querySelector('.when');
-		when && (when.textContent = 'TIDSPUNKT');
-
-		const duration = this.shadow.querySelector('.duration');
-		duration && (duration.textContent = 'VARIGHED');
+		if (where && resultData.creator_affiliation) {
+			where.textContent = resultData.creator_affiliation[0] + ',';
+		}
 
 		const summary = this.shadow.querySelector('.summary');
 		summary &&
@@ -79,10 +75,18 @@ class ResultComponent extends HTMLElement {
 	}
 
 	attributeChangedCallback(name: string, oldValue: string, newValue: string) {
-		if (name === 'number') {
-			const number = this.shadow.querySelector('number');
-			this.number = Number(newValue);
-			number && (number.textContent = Number(newValue + 1).toString());
+		if (name === 'duration') {
+			const duration = this.shadow.querySelector('.duration');
+
+			if (duration && newValue !== undefined) {
+				duration.textContent = newValue;
+			}
+		}
+		if (name === 'starttime') {
+			const when = this.shadow.querySelector('.when');
+			if (when && newValue !== undefined) {
+				when.textContent = newValue;
+			}
 		}
 		if (name === 'show') {
 			if (newValue === 'false') {
@@ -93,9 +97,6 @@ class ResultComponent extends HTMLElement {
 				this.style.transform = 'translateY(0px)'; */
 			}
 		}
-		if (name === 'vueRouting') {
-			newValue === 'true' ? (this.vueRouting = true) : (this.vueRouting = false);
-		}
 	}
 }
 
@@ -104,10 +105,10 @@ const RESULT_COMPONENT_TEMPLATE = /*html*/ `
 		<div class="information">
 		<a role="link" class="title"></a>
 		<div class="subtitle">
-			<span class="material-icons icons">tv</span>
+			<span class="material-icons icons tv">tv</span>
 			<span class="where"></span>
 			<span class="when"></span>
-			<span class="material-icons icons">schedule</span>
+			<span class="material-icons icons schedule">schedule</span>
 			<span class="duration"></span>
 		</div>
 			<div class="summary"></div>
@@ -182,9 +183,13 @@ const RESULT_COMPONENT_STYLES = /*css*/ `
 		}
 
 		.where, .when, .duration {
-			padding-right:15px;
+			padding-right:5px;
 			text-overflow: ellipsis;
 			font-size:14px;
+		}
+
+		.where:empty, .when:empty, .duration:empty {
+			padding:0px;
 		}
 		.summary {
 			overflow: hidden;

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -11,6 +11,9 @@
      "goToPage":"Gå til side {n}"
    },
   "record":{
+     "duration":"Varighed",
+     "noBoardcastData":"Ingen sendetid",
+     "timestamp":"kl. ",
      "title":"Titel",
      "genre":"Genre",
      "copy": "Kopier henvisning til dette indhold",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -11,6 +11,9 @@
      "goToPage":"Go to page {n}"
   },
   "record":{
+     "duration":"Duration",
+     "noBoardcastData":"No air date",
+     "timestamp": "at ",
      "title":"Title",
      "genre":"Genre",
      "copy":"Copy reference for this content",

--- a/src/types/GenericSearchResultTypes.ts
+++ b/src/types/GenericSearchResultTypes.ts
@@ -23,12 +23,16 @@ export interface GenericSearchResultType {
 	list_of_categories: string[];
 	place_of_production: string;
 	resource_description: string;
+	creator_affiliation: string[];
 	shelf_location: string;
 	title: string;
 	topic: string[];
 	type_of_resource: string[];
 	thumbnail: string;
 	_version: number;
+	startTime?: string;
+	endTime?: string;
+	duration?: string;
 }
 
 export interface FacetsType {

--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -1,0 +1,99 @@
+import { ComposerTranslation } from 'vue-i18n';
+
+function calculateDuration(startDate: string, endDate: string, t: ComposerTranslation) {
+	const startDateObj = new Date(startDate);
+	const endDateObj = new Date(endDate);
+	let formattedDuration;
+
+	const isStartDateValid = startDate && !isNaN(startDateObj.getTime());
+	const isEndDateValid = endDate && !isNaN(endDateObj.getTime());
+
+	if (isStartDateValid && isEndDateValid) {
+		const duration = endDateObj.getTime() - startDateObj.getTime();
+
+		if (!isNaN(duration)) {
+			const hours = Math.floor(duration / 3600000);
+			const minutes = Math.floor((duration % 3600000) / 60000);
+			const seconds = Math.floor((duration % 60000) / 1000);
+			const durationParts = generateDurationParts(hours, minutes, seconds, t);
+			return (formattedDuration = durationParts.join(' '));
+		}
+	}
+	return (formattedDuration = t('duration.unknown'));
+}
+
+function formatDuration(
+	isoDuration: string | undefined,
+	startDate: string | undefined,
+	endDate: string | undefined,
+	t: ComposerTranslation,
+): string {
+	let formattedDuration = '';
+
+	if (isoDuration && isoDuration !== '') {
+		const match = isoDuration.match(/PT(\d+H)?(\d+M)?(\d+S)?/);
+		if (match) {
+			const hours = parseInt(match[1] || '0');
+			const minutes = parseInt(match[2] || '0');
+			const seconds = parseInt(match[3] || '0');
+			const durationParts = generateDurationParts(hours, minutes, seconds, t);
+			formattedDuration = durationParts.join(' ');
+		} else {
+			if (startDate && endDate) {
+				//If the matcher does not come through - do manual calc
+				formattedDuration = calculateDuration(startDate, endDate, t);
+			} else {
+				formattedDuration = t('duration.unknown');
+			}
+		}
+	} else if (startDate && endDate) {
+		//If there is no duration at all or it is empty - do manual calc
+		formattedDuration = calculateDuration(startDate, endDate, t);
+	} else {
+		formattedDuration = t('duration.unknown');
+	}
+	return formattedDuration;
+}
+
+function generateDurationParts(hours: number, minutes: number, seconds: number, t: ComposerTranslation) {
+	const durationParts: string[] = [];
+	if (hours > 0) {
+		durationParts.push(`${hours}${t('duration.hours')}`);
+	}
+	if (minutes > 0) {
+		durationParts.push(`${minutes}${t('duration.minutes')}`);
+	}
+	if (seconds > 0) {
+		durationParts.push(`${seconds}${t('duration.seconds')}`);
+	}
+	return durationParts;
+}
+
+function getBroadcastDate(isoDate: string, locale: string): string {
+	const date = new Date(isoDate);
+
+	// Define formatting options - had to do the weird const typing...
+	const options = {
+		year: 'numeric' as const,
+		month: 'long' as const,
+		day: 'numeric' as const,
+	};
+
+	return locale === 'da'
+		? new Intl.DateTimeFormat('da-DK', options).format(date)
+		: new Intl.DateTimeFormat('en-GB', options).format(date);
+}
+function getBroadcastTime(isoDate: string): string {
+	const dateObj = new Date(isoDate);
+
+	// Formatting options - had to do the weird const typing...
+	const options = {
+		hour: '2-digit' as const,
+		minute: '2-digit' as const,
+		hour12: false as const,
+	};
+
+	return new Intl.DateTimeFormat('en-GB', options).format(dateObj);
+}
+
+export { formatDuration, getBroadcastDate, getBroadcastTime };


### PR DESCRIPTION
So, this got a little bigger than intended:

Added channel, time and duration to the search results.
Made sure we handle if nothing is there in a somewhat decent way (for now).
Moved and refactored some time util methods so they can be used by everyone.
Did some translation stuff to make sure everything, that can be, is translated.