### PR TITLE
Fix for broken duration unit tests

### DIFF
--- a/tests/unit/Duration.spec.ts
+++ b/tests/unit/Duration.spec.ts
@@ -1,155 +1,154 @@
 import { mount } from '@vue/test-utils';
 import { createI18n } from 'vue-i18n';
-import Duration from '@/components/records/components/Duration.vue';
+import Duration from '@/components/common/Duration.vue';
 
-describe('Duration.vue', () => {
-	const i18n = createI18n({
-		locale: 'en',
-		legacy: false,
-		messages: {
-			en: {
-				duration: {
-					hours: 'hours',
-					minutes: 'minutes',
-					seconds: 'seconds',
-					unknown: 'Duration unknown',
+const locales = ['en', 'da'];
+
+locales.forEach((locale) => {
+	//Yes you can du this to prompt the locale in case of an error:)
+	describe(`Duration.vue (${locale} locale)`, () => {
+		const i18n = createI18n({
+			locale,
+			legacy: false,
+			messages: {
+				en: {
+					duration: {
+						hours: 'h',
+						minutes: 'min',
+						seconds: 'sec',
+						unknown: 'Duration unknown',
+					},
 				},
-			},
-		},
-	});
-
-	it('renders formatted duration when isoDuration prop is provided', async () => {
-		const wrapper = mount(Duration, {
-			props: {
-				isoDuration: 'PT2H30M45S',
-				startDate: '2023-09-22T10:00:00',
-				endDate: '2023-09-22T12:30:45',
-			},
-			global: {
-				plugins: [i18n],
+				da: {
+					duration: {
+						hours: 't',
+						minutes: 'min',
+						seconds: 'sek',
+						unknown: 'Ukendt længde',
+					},
+				},
 			},
 		});
 
-		await wrapper.vm.$nextTick();
-		const spanElement = wrapper.find('span');
-		expect(spanElement.text()).toContain('(2hours 30minutes 45seconds)');
-	});
+		//Put the typing locally here instead of dedicated in types folder as this is a mock props type
+		const createWrapper = (props: { isoDuration?: string; startDate?: string; endDate?: string }) => {
+			return mount(Duration, {
+				props,
+				global: {
+					plugins: [i18n],
+				},
+			});
+		};
 
-	it('renders formatted duration when isoDuration prop is empty but startDate and endDate prop exist', async () => {
-		const wrapper = mount(Duration, {
-			props: {
+		it('renders formatted duration when isoDuration prop is provided', async () => {
+			const props = {
+				isoDuration: 'PT2H30M45S',
+				startDate: '2023-09-22T10:00:00',
+				endDate: '2023-09-22T12:30:45',
+			};
+
+			const wrapper = createWrapper(props);
+			await wrapper.vm.$nextTick();
+			const spanElement = wrapper.find('span');
+			const expectedText = locale === 'en' ? '(2h 30min 45sec)' : '(2t 30min 45sek)';
+			expect(spanElement.text()).toContain(expectedText);
+		});
+
+		it('renders formatted duration when isoDuration prop is empty but startDate and endDate prop exist', async () => {
+			const props = {
 				isoDuration: '',
 				startDate: '2023-09-22T10:00:00',
 				endDate: '2023-09-22T12:30:45',
-			},
-			global: {
-				plugins: [i18n],
-			},
+			};
+
+			const wrapper = createWrapper(props);
+			await wrapper.vm.$nextTick();
+			const spanElement = wrapper.find('span');
+			const expectedText = locale === 'en' ? '(2h 30min 45sec)' : '(2t 30min 45sek)';
+			expect(spanElement.text()).toContain(expectedText);
 		});
 
-		await wrapper.vm.$nextTick();
-		const spanElement = wrapper.find('span');
-		expect(spanElement.text()).toContain('(2hours 30minutes 45seconds)');
-	});
-
-	it('renders formatted duration when isoDuration prop is not provided but startDate and endDate prop are', async () => {
-		const wrapper = mount(Duration, {
-			props: {
+		it('renders formatted duration when isoDuration prop is not provided but startDate and endDate prop are', async () => {
+			const props = {
 				startDate: '2023-09-22T10:00:00',
 				endDate: '2023-09-22T12:30:45',
-			},
-			global: {
-				plugins: [i18n],
-			},
+			};
+
+			const wrapper = createWrapper(props);
+			await wrapper.vm.$nextTick();
+			const spanElement = wrapper.find('span');
+			const expectedText = locale === 'en' ? '(2h 30min 45sec)' : '(2t 30min 45sek)';
+			expect(spanElement.text()).toContain(expectedText);
 		});
 
-		await wrapper.vm.$nextTick();
-		const spanElement = wrapper.find('span');
-		expect(spanElement.text()).toContain('(2hours 30minutes 45seconds)');
-	});
-
-	it('renders formatted duration when startDate or endDate props are missing but isoDuration exists', async () => {
-		const wrapper = mount(Duration, {
-			props: {
+		it('renders formatted duration when startDate or endDate props are missing but isoDuration exists', async () => {
+			const props = {
 				isoDuration: 'PT2H30M45S',
 				startDate: '2023-09-22T10:00:00',
 				endDate: '',
-			},
-			global: {
-				plugins: [i18n],
-			},
+			};
+
+			const wrapper = createWrapper(props);
+			await wrapper.vm.$nextTick();
+			const spanElement = wrapper.find('span');
+			const expectedText = locale === 'en' ? '(2h 30min 45sec)' : '(2t 30min 45sek)';
+			expect(spanElement.text()).toContain(expectedText);
 		});
 
-		await wrapper.vm.$nextTick();
-		const spanElement = wrapper.find('span');
-		expect(spanElement.text()).toContain('(2hours 30minutes 45seconds)');
-	});
-
-	it('renders formatted duration when isoDuration is not a valid duration format but startDate and endDate props', async () => {
-		const wrapper = mount(Duration, {
-			props: {
+		it('renders formatted duration when isoDuration is not a valid duration format but startDate and endDate props', async () => {
+			const props = {
 				isoDuration: 'invalid-duration',
 				startDate: '2023-09-22T10:00:00',
 				endDate: '2023-09-22T12:30:45',
-			},
-			global: {
-				plugins: [i18n],
-			},
+			};
+
+			const wrapper = createWrapper(props);
+			await wrapper.vm.$nextTick();
+			const spanElement = wrapper.find('span');
+			const expectedText = locale === 'en' ? '(2h 30min 45sec)' : '(2t 30min 45sek)';
+			expect(spanElement.text()).toContain(expectedText);
 		});
 
-		await wrapper.vm.$nextTick();
-		const spanElement = wrapper.find('span');
-		expect(spanElement.text()).toContain('(2hours 30minutes 45seconds)');
-	});
-
-	it('renders "Duration unknown" when isoDuration is not a valid duration format and startDate is missing', async () => {
-		const wrapper = mount(Duration, {
-			props: {
+		it('renders "Duration unknown" when isoDuration is not a valid duration format and startDate is missing', async () => {
+			const props = {
 				isoDuration: 'invalid-duration',
 				startDate: '',
 				endDate: '2023-09-22T12:30:45',
-			},
-			global: {
-				plugins: [i18n],
-			},
+			};
+
+			const wrapper = createWrapper(props);
+			await wrapper.vm.$nextTick();
+			const spanElement = wrapper.find('span');
+			const expectedText = locale === 'en' ? 'Duration unknown' : 'Ukendt længde';
+			expect(spanElement.text()).toContain(expectedText);
 		});
 
-		await wrapper.vm.$nextTick();
-		const spanElement = wrapper.find('span');
-		expect(spanElement.text()).toContain('Duration unknown');
-	});
-
-	it('renders "Duration unknown" when isoDuration is not a valid duration format and endDate prop is provided but startDate is missing', async () => {
-		const wrapper = mount(Duration, {
-			props: {
+		it('renders "Duration unknown" when isoDuration is not a valid duration format and endDate prop is provided but startDate is missing', async () => {
+			const props = {
 				isoDuration: 'invalid-duration',
 				startDate: '',
 				endDate: '2023-09-22T12:30:45',
-			},
-			global: {
-				plugins: [i18n],
-			},
+			};
+
+			const wrapper = createWrapper(props);
+			await wrapper.vm.$nextTick();
+			const spanElement = wrapper.find('span');
+			const expectedText = locale === 'en' ? 'Duration unknown' : 'Ukendt længde';
+			expect(spanElement.text()).toContain(expectedText);
 		});
 
-		await wrapper.vm.$nextTick();
-		const spanElement = wrapper.find('span');
-		expect(spanElement.text()).toContain('Duration unknown');
-	});
-
-	it('renders "Duration unknown" when isoDuration is not a valid duration format and endDate is provided but startDate is invalid format', async () => {
-		const wrapper = mount(Duration, {
-			props: {
+		it('renders "Duration unknown" when isoDuration is not a valid duration format and endDate is provided but startDate is invalid format', async () => {
+			const props = {
 				isoDuration: 'invalid-duration',
 				startDate: 'invalid-start',
 				endDate: '2023-09-22T12:30:45',
-			},
-			global: {
-				plugins: [i18n],
-			},
-		});
+			};
 
-		await wrapper.vm.$nextTick();
-		const spanElement = wrapper.find('span');
-		expect(spanElement.text()).toContain('Duration unknown');
+			const wrapper = createWrapper(props);
+			await wrapper.vm.$nextTick();
+			const spanElement = wrapper.find('span');
+			const expectedText = locale === 'en' ? 'Duration unknown' : 'Ukendt længde';
+			expect(spanElement.text()).toContain(expectedText);
+		});
 	});
 });


### PR DESCRIPTION
I fixed the errors and adjusted them to take both locales into account as well as the new translations.

Just run the unit tests with npm run test:unit and see if the pass:)