### PR TITLE
First stab at eslint fix and some linting too

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,11 +3,7 @@ module.exports = {
 	env: {
 		node: true,
 	},
-	extends: [
-		'plugin:vue/vue3-essential',
-		'eslint:recommended',
-		'@vue/typescript/recommended',
-	],
+	extends: ['plugin:vue/vue3-essential', 'eslint:recommended', '@vue/typescript/recommended'],
 	plugins: ['prettier'],
 	parserOptions: {
 		ecmaVersion: 2020,
@@ -16,7 +12,9 @@ module.exports = {
 		'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
 		'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
 		'vue/multi-word-component-names': 'off',
+		'prettier/prettier': 'error',
 		semi: ['error', 'always'],
+		'no-mixed-spaces-and-tabs': 'off',
 	},
 	overrides: [
 		{

--- a/src/components/global/nav/wc-header-menu.ts
+++ b/src/components/global/nav/wc-header-menu.ts
@@ -92,7 +92,7 @@ class MenuComponent extends HTMLElement {
 			localeSwitcher
 				? localeSwitcher.addEventListener('click', (e) => {
 						this.dispatchLocaleSwitch(e);
-				})
+				  })
 				: null;
 		}
 	}

--- a/src/components/search/Sort.vue
+++ b/src/components/search/Sort.vue
@@ -12,8 +12,8 @@
 								? t('search.sortAfter') + t('search.' + searchResultStore.sort.split('%20')[0])
 								: t('search.sortBy')
 							: searchResultStore.sort !== ''
-							? t('search.sortAfter') + t('search.' + searchResultStore.sort.split('%20')[0])
-							: t('search.sortBy')
+							  ? t('search.sortAfter') + t('search.' + searchResultStore.sort.split('%20')[0])
+							  : t('search.sortBy')
 					}}
 				</span>
 				<span :class="showSortingOptions ? 'material-icons sort-expand turn' : 'material-icons sort-expand'">
@@ -113,8 +113,8 @@ export default defineComponent({
 	position: absolute;
 	width: 100%;
 	box-shadow:
-	rgba(0, 0, 0, 0.16) 0px 3px 6px,
-	rgba(0, 0, 0, 0.23) 0px 3px 6px;
+		rgba(0, 0, 0, 0.16) 0px 3px 6px,
+		rgba(0, 0, 0, 0.23) 0px 3px 6px;
 }
 
 .sort-options button {

--- a/src/components/search/wc-facet-checkbox.ts
+++ b/src/components/search/wc-facet-checkbox.ts
@@ -27,7 +27,7 @@ class checkboxComponent extends HTMLElement {
 							},
 						}),
 					);
-				})
+			  })
 			: null;
 
 		const observer = new IntersectionObserver((entries) => {

--- a/src/components/search/wc-searchbar.ts
+++ b/src/components/search/wc-searchbar.ts
@@ -37,14 +37,14 @@ class SearchBarComponent extends HTMLElement {
 		searchButton
 			? searchButton.addEventListener('click', (e) => {
 					this.dispatchSearch(e);
-				})
+			  })
 			: null;
 
 		const resetButton: HTMLButtonElement | null = this.shadow.querySelector('#resetButton');
 		resetButton
 			? resetButton.addEventListener('click', (e) => {
 					this.resetSearch(e);
-				})
+			  })
 			: null;
 
 		// de values are subject to change here
@@ -54,21 +54,21 @@ class SearchBarComponent extends HTMLElement {
 		limitAll
 			? limitAll.addEventListener('click', () => {
 					this.setDelimitationAndDispatch(this.getPresetFilter('all'));
-				})
+			  })
 			: null;
 
 		const limitTv: HTMLInputElement | null = this.shadow.querySelector('.selectTv');
 		limitTv
 			? limitTv.addEventListener('click', () => {
 					this.setDelimitationAndDispatch(this.getPresetFilter('tv'));
-				})
+			  })
 			: null;
 
 		const limitRadio: HTMLInputElement | null = this.shadow.querySelector('.selectRadio');
 		limitRadio
 			? limitRadio.addEventListener('click', () => {
 					this.setDelimitationAndDispatch(this.getPresetFilter('radio'));
-				})
+			  })
 			: null;
 		this.setResetVisibility(false);
 	}

--- a/src/views/ShowRecord.vue
+++ b/src/views/ShowRecord.vue
@@ -32,7 +32,7 @@ import BroadcastVideoRecordMetadataView from '@/components/records/BroadcastVide
 import BroadcastAudioRecordMetadataView from '@/components/records/BroadcastAudioRecord.vue';
 
 import { useI18n } from 'vue-i18n';
-import { Axios, AxiosError } from 'axios';
+import { AxiosError } from 'axios';
 
 //Types
 import { BroadcastRecordType } from '@/types/BroadcastRecordType';


### PR DESCRIPTION
First stab at fixing our crazy linter problems...

Tinkered with the eslint configuration and reintroduced the eslint-prettier integration.

It would be nice if you tried the following:

First clear node_modules and run `npm install`. You will be prompted if you try this with the wring node version.

Then:

- Mess with indention in some files and press save and see that it is fixed instantly to your liking
- Try to remove a semicolon from a line and pres save and see that it is fixed instantly to your liking
- Try to change some single quotes to double quotes press save and see that it is fixed instantly to your liking
- Try to remove a dangling (e.g. line 92 in SearchResults.vue) press save and see that it is fixed instantly to your liking

Finally try `npm run lint` and see that it runs without a hitch. If you go the final mile than try to mess up some indention and then run `npm run lint` and see that it gets auto fixed.