### PR TITLE
DISC-760/Fix broken images

### DIFF
--- a/src/components/common/wc-image-item.ts
+++ b/src/components/common/wc-image-item.ts
@@ -1,12 +1,6 @@
 import { ImageComponentType } from '@/types/ImageComponentType';
 
-class ImageComponent extends HTMLElement implements ImageComponentType {
-	imgSrc: string | undefined;
-	imgTitle: string | undefined;
-	altText: string | undefined;
-	icon: string | undefined;
-	aspect: string | undefined;
-	placeholder: string | undefined;
+class ImageComponent extends HTMLElement {
 	constructor() {
 		super();
 		this.innerHTML = IMAGE_COMPONMENT_TEMPLATE + IMAGE_COMPONMENT_STYLES;
@@ -17,38 +11,40 @@ class ImageComponent extends HTMLElement implements ImageComponentType {
 		}
 	}
 
+	static get observedAttributes() {
+		return ['imagedata'];
+	}
+
 	showImage() {
 		this.style.opacity = '1';
 	}
 
-	connectedCallback() {
-		const thumb = this.querySelector('.image-item') as HTMLImageElement;
-		if (this.imgSrc !== undefined) {
-			thumb && (thumb.src = this.imgSrc);
-		} else if (this.placeholder !== undefined) {
-			thumb && (thumb.src = this.placeholder);
-			thumb.style.backgroundColor = 'rgb(237,237,237)';
-			thumb.style.objectFit = 'contain';
-		}
-		if (this.altText && this.querySelector('.image-item')) {
-			this.querySelector('.image-item')?.setAttribute('alt', this.altText);
-		}
-		if (this.imgTitle && this.querySelector('.image-item')) {
-			this.querySelector('.image-item')?.setAttribute('title', this.imgTitle);
-		}
-		if (this.icon) {
-			const iconHolder = this.querySelector('.type-symbol');
-			iconHolder && (iconHolder.textContent = this.icon);
-		}
-		if (this.aspect) {
-			const imageWrapper = this.querySelector('.image-wrapper') as HTMLElement;
-			imageWrapper && (imageWrapper.style.aspectRatio = this.aspect);
-		}
-	}
-
 	attributeChangedCallback(name: string, oldValue: string, newValue: string) {
-		if (name === 'locale') {
-			this.lang = newValue;
+		if (name === 'imagedata') {
+			const imageData = JSON.parse(newValue) as ImageComponentType;
+			const thumb = this.querySelector('.image-item') as HTMLImageElement;
+			if (imageData.imgSrc !== undefined) {
+				thumb && (thumb.src = imageData.imgSrc);
+			}
+			if (imageData.placeholder !== undefined) {
+				thumb && (thumb.src = imageData.placeholder);
+				thumb.style.backgroundColor = 'rgb(237,237,237)';
+				thumb.style.objectFit = 'contain';
+			}
+			if (imageData.altText && this.querySelector('.image-item')) {
+				this.querySelector('.image-item')?.setAttribute('alt', imageData.altText);
+			}
+			if (imageData.imgTitle && this.querySelector('.image-item')) {
+				this.querySelector('.image-item')?.setAttribute('title', imageData.imgTitle);
+			}
+			if (imageData.icon) {
+				const iconHolder = this.querySelector('.type-symbol');
+				iconHolder && (iconHolder.textContent = imageData.icon);
+			}
+			if (imageData.aspect) {
+				const imageWrapper = this.querySelector('.image-wrapper') as HTMLElement;
+				imageWrapper && (imageWrapper.style.aspectRatio = imageData.aspect);
+			}
 		}
 	}
 }

--- a/src/components/common/wc-spot-item.ts
+++ b/src/components/common/wc-spot-item.ts
@@ -14,12 +14,14 @@ class SpotComponent extends HTMLElement {
 
 		const imageComponent = this.shadow.querySelector('kb-imagecomponent') as ImageComponentType;
 		if (imageComponent) {
+			const imageData = {} as ImageComponentType;
 			//No data yet, so it's just filler
-			imageComponent.imgSrc = '';
-			imageComponent.altText = 'alt text here';
-			imageComponent.imgTitle = 'title here';
-			imageComponent.aspect = '2/1.25';
-			imageComponent.icon = 'play_arrow';
+			imageData.imgSrc = '';
+			imageData.altText = 'alt text here';
+			imageData.imgTitle = 'title here';
+			imageData.aspect = '2/1.25';
+			imageData.icon = 'play_arrow';
+			imageComponent.setAttribute('imagedata', JSON.stringify(imageData));
 		}
 	}
 

--- a/src/components/search/wc-result-item.ts
+++ b/src/components/search/wc-result-item.ts
@@ -117,10 +117,12 @@ class ResultComponent extends HTMLElement {
 			where && (where.textContent = this.data.creator_affiliation[0] + ',');
 			const imageComponent = this.shadow.querySelector('kb-imagecomponent') as ImageComponentType;
 			if (imageComponent) {
-				imageComponent.imgSrc = this.data.thumbnail;
-				imageComponent.altText = this.data.title;
-				imageComponent.imgTitle = this.data.title;
-				imageComponent.placeholder = this.placeholder;
+				const imageData = {} as ImageComponentType;
+				imageData.imgSrc = this.data.thumbnail;
+				imageData.altText = this.data.title;
+				imageData.imgTitle = this.data.title;
+				imageData.placeholder = this.placeholder;
+				imageComponent.setAttribute('imagedata', JSON.stringify(imageData));
 			}
 		}
 	}


### PR DESCRIPTION
A fairly straight forward rework.

The image now takes one property - imagedata, which we observe. If it changed, we update all the stuff. For now, we don't really have any images to show, but the placeholder shows up, and everything reacts as it should. So this will work for now untill we get a better idea of how to handle images/thumbnails/players.

Also works for both the result-item and the spot-item on the frontpage, so that's good.