### PR TITLE
DRA-146 only loading player when the streaming url is there

### DIFF
--- a/src/components/records/BroadcastAudioRecord.vue
+++ b/src/components/records/BroadcastAudioRecord.vue
@@ -1,6 +1,7 @@
 <template>
 	<div class="broadcast-record">
-		<AudioPlayer :audio-url="recordData.contentUrl"></AudioPlayer>
+		<AudioPlayer v-if="recordData.contentUrl" :audio-url="recordData.contentUrl"></AudioPlayer>
+		<div class="no-streaming" v-else>{{  t('record.missingStreamingUrl') }}</div>
 		<div class="boardcast-record-data">
 			<div class="main-record-data">
 				<div class="record-data">
@@ -148,6 +149,16 @@ temporary styling until patterns from design system are implemented
 .back-link {
 	width: 100%;
 	margin-bottom: 10px;
+}
+
+.no-streaming {
+	width:100%;
+	background-color:black;
+	display:flex;
+	height:300px;
+	color:white;
+	align-items: center;
+  justify-content: center;
 }
 
 .back-link a {

--- a/src/components/records/BroadcastVideoRecord.vue
+++ b/src/components/records/BroadcastVideoRecord.vue
@@ -1,6 +1,7 @@
 <template>
 	<div class="broadcast-record">
-		<VideoPlayer :video-url="recordData.contentUrl"></VideoPlayer>
+		<VideoPlayer v-if="recordData.contentUrl" :video-url="recordData.contentUrl"></VideoPlayer>
+		<div class="no-streaming" v-else>{{  t('record.missingStreamingUrl') }}</div>
 		<div class="boardcast-record-data">
 			<div class="main-record-data">
 				<div class="record-data">
@@ -152,6 +153,16 @@ temporary styling until patterns from design system are implemented
 
 .back-link a {
 	text-decoration: none;
+}
+
+.no-streaming {
+	width:100%;
+	background-color:black;
+	display:flex;
+	height:300px;
+	color:white;
+	align-items: center;
+  justify-content: center;
 }
 
 .get-link {

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -35,7 +35,8 @@
      "copyMessageSuccess":"Linket var successfuldt kopieret til klipboardet.",
      "copyTitleFailed":"Kopiering fejlede.",
      "copyMessageFailed":"Linket blev ikke kopieret til klipboardet. Kopier URL istedet.",
-     "moreMetadataBroadcast":"Yderligere information om udsendelsen"
+     "moreMetadataBroadcast":"Yderligere information om udsendelsen",
+     "missingStreamingUrl":"Vi beklager, men denne post har ingen steaming URL, \n så der er intet at vise."
     
   },
   "duration":{

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -35,7 +35,9 @@
      "copyMessageSuccess":"The link was successfully copied to the clipboard.",
      "copyTitleFailed":"Copying failed.",
      "copyMessageFailed":"The link was not copied to the clipboard. Copy the URL instead.",
-     "moreMetadataBroadcast":"Additional information about the broadcast"
+     "moreMetadataBroadcast":"Additional information about the broadcast",
+     "missingStreamingUrl":"We're sorry, it seems this record has no streaming URL, \n so there is nothing to show."
+
   },
   "duration":{
    "hours":"h",

--- a/src/views/ShowRecord.vue
+++ b/src/views/ShowRecord.vue
@@ -101,6 +101,7 @@ export default defineComponent({
 			if (recordResp) {
 				recordType.value = recordResp.data['@type'];
 				recordData.value = recordResp.data;
+				console.log(recordData.value,"heres the record!");
 			}
 			if (moreLikeThis) {
 				moreLikeThisRecords.value = moreLikeThis.data.response.docs;


### PR DESCRIPTION
So, I've added a check to see if we have a streaming URL. If we do, then we show the player. Otherwise we show a very neutral message of "we dont have the url for this".

This is just the first stab - i guess we need Design/UX to make a proper layout for this - but functionality-wise, this should be the trick.

Added for both radio and TV. Feel free to message me for 2 links, one that has an url, and one that doesn't :-) (I don't wanna share the uuids here for one of each type).