### PR TITLE
DRA-90 - Should fix the opt-out

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "preview": "vite preview",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
     "test:unit": "vue-cli-service test:unit",
-    "test:lh": "dotenv -e .env.local cross-var lighthouse %LIGHTHOUSE_TARGET_URL% -- --view",
-    "test:full": "vue-cli-service test:unit && dotenv -e .env.local cross-var lighthouse %LIGHTHOUSE_TARGET_URL% -- --view"
+    "test:lh": "dotenv -e .env.local cross-var lighthouse %LIGHTHOUSE_TARGET_URL% -- --view --no-enable-error-reporting",
+    "test:full": "vue-cli-service test:unit && dotenv -e .env.local cross-var lighthouse %LIGHTHOUSE_TARGET_URL% -- --view --no-enable-error-reporting"
   },
   "dependencies": {
     "axios": "^1.6.2",


### PR DESCRIPTION
So, this should fix it, after reading through the docs here:
https://github.com/GoogleChrome/lighthouse/blob/main/docs/error-reporting.md

Delete your ~/.config/configstore/lighthouse.json to test if it indeed opts out. Another problem is that the .env file is no longer valid, since it states that Lighthouse should look at port 8080, instead of 3000 where it's now running. A fix has been added in that repo too.