### PR TITLE
Dra 361/thumbnails in search results

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -244,7 +244,7 @@ export default defineComponent({
 	top: 0px;
 	left: 0px;
 	width: 100%;
-	z-index: 1000;
+	z-index: 5;
 	text-align: center;
 	background: #002e70;
 

--- a/src/api/api-client.ts
+++ b/src/api/api-client.ts
@@ -105,4 +105,8 @@ export class APIServiceClient {
 	async getThumbnail(id: string): Promise<APIThumbnailsResponseType> {
 		return await this.httpClient.get(`thumbnails/?fileId=${id}&width=200&height=105`);
 	}
+
+	async getExtraThumbnails(id: string): Promise<APIThumbnailsResponseType> {
+		return await this.httpClient.get(`thumbnails/?fileId=${id}&width=200&vid_slices=10`);
+	}
 }

--- a/src/components/common/wc-image-item.ts
+++ b/src/components/common/wc-image-item.ts
@@ -7,6 +7,9 @@ class ImageComponent extends HTMLElement {
 		this.shadow = this.attachShadow({ mode: 'open' });
 		this.shadow.innerHTML = IMAGE_COMPONMENT_TEMPLATE + IMAGE_COMPONMENT_STYLES;
 		const imageWrapper: HTMLDivElement | null = this.shadow.querySelector('.image-wrapper');
+		if (imageWrapper) {
+			imageWrapper.style.background = `linear-gradient(${Math.round(Math.random() * 360)}deg, #caf0fe, #002e70)`;
+		}
 		const image: HTMLImageElement | null = this.shadow.querySelector('.image-item');
 		if (image && imageWrapper) {
 			image.addEventListener('load', this.showImage);
@@ -31,6 +34,9 @@ class ImageComponent extends HTMLElement {
 			if (imageData.placeholder !== undefined) {
 				thumb && (thumb.src = imageData.placeholder);
 				thumb.style.backgroundColor = 'rgb(237,237,237)';
+			}
+			if (imageData.objectPos !== undefined) {
+				thumb.style.objectPosition = imageData.objectPos;
 			}
 			if (imageData.imgOption !== undefined) {
 				thumb.style.objectFit = imageData.imgOption;
@@ -94,7 +100,7 @@ const IMAGE_COMPONMENT_STYLES = /*css*/ `
 
     .image-wrapper {
 				overflow: hidden;
-        background: linear-gradient(45deg, #caf0fe, #fff6c4);
+        background: linear-gradient(45deg, #caf0fe, #002e70);
         width:100%;
 				height:100%;
         padding:0px;
@@ -102,20 +108,31 @@ const IMAGE_COMPONMENT_STYLES = /*css*/ `
         margin-block-end: 0em;
         margin-inline-start: 0px;
         margin-inline-end: 0px;
-        transition:all 0.3s ease-in-out 0s;
+        transition:opacity 0.3s ease-in-out 0s, filter 0.3s ease-in-out 0s, transform 0.3s ease-in-out 0s;
         filter:hue-rotate(var(--image-item-hue-rotation));
+				animation: rotateGradient 2s linear infinite; /* Apply the animation */
+
     }
 
     .image-item {
         width:100%;
         height:100%;
         object-fit: cover;
-        transition:all 0.5s ease-in-out 0s;
+        transition:opacity 0.3s ease-in-out 0s, filter 0.3s ease-in-out 0s, transform 0.3s ease-in-out 0s;
         opacity:0;
 				transform:scale3d(var(--image-item-scale), var(--image-item-scale) ,var(--image-item-scale));
 				transform-origin:center;
 				will-change: transform;
     }
+
+		@keyframes rotateGradient {
+			from {
+				background-position: 0% 0%;
+			}
+			to {
+				background-position: 100% 100%;
+			}
+		}
 	</style>`;
 
 customElements.define('kb-imagecomponent', ImageComponent);

--- a/src/components/common/wc-image-item.ts
+++ b/src/components/common/wc-image-item.ts
@@ -62,6 +62,7 @@ class ImageComponent extends HTMLElement {
 const IMAGE_COMPONMENT_TEMPLATE = /*html*/ `
         <figure class="image-wrapper">
             <img
+								draggable="false"
                 loading="lazy"
                 class="image-item"
             /><span class="type-symbol material-icons"></span>
@@ -123,6 +124,12 @@ const IMAGE_COMPONMENT_STYLES = /*css*/ `
 				transform:scale3d(var(--image-item-scale), var(--image-item-scale) ,var(--image-item-scale));
 				transform-origin:center;
 				will-change: transform;
+				-webkit-user-select: none;
+				-khtml-user-select: none;
+				-moz-user-select: none;
+				-o-user-select: none;
+				-ms-user-select: none;
+				user-select: none;
     }
 
 		@keyframes rotateGradient {

--- a/src/components/records/BroadcastVideoRecord.vue
+++ b/src/components/records/BroadcastVideoRecord.vue
@@ -1,10 +1,15 @@
 <template>
 	<div class="broadcast-record">
 		<div class="video-container">
-			<VideoPlayer
-				v-if="recordData.contentUrl"
-				:file-id="recordData['kb:internal']['kb:file_id']"
-			></VideoPlayer>
+			<div v-if="recordData.contentUrl">
+				<VideoPlayer :file-id="recordData['kb:internal']['kb:file_id']"></VideoPlayer>
+				<AdditionalInfo
+					:id="recordData.id"
+					:open="true"
+					:file-id="recordData['kb:internal']['kb:file_id'] ? recordData['kb:internal']['kb:file_id'] : ''"
+					:duration="getTimeFromStartAndEnde(recordData.duration)"
+				></AdditionalInfo>
+			</div>
 			<div
 				v-else
 				class="no-streaming"
@@ -108,7 +113,8 @@ import { copyTextToClipboard } from '@/utils/copy-script';
 import { getBroadcastDate, getBroadcastTime } from '@/utils/time-utils';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
-
+import AdditionalInfo from '@/components/search/AdditionalInfo.vue';
+import { getTimeFromStartAndEnde } from '@/utils/time-utils';
 import '@/components/common/wc-accordian';
 import '@/components/common/wc-spot-item';
 
@@ -119,6 +125,7 @@ export default defineComponent({
 		VideoPlayer,
 		Duration,
 		GridDisplay,
+		AdditionalInfo,
 	},
 
 	props: {
@@ -148,7 +155,7 @@ export default defineComponent({
 			copyTextToClipboard();
 		};
 
-		return { lastPath, locale, t, getCurrentUrl, getBroadcastDate, getBroadcastTime };
+		return { lastPath, locale, t, getCurrentUrl, getBroadcastDate, getBroadcastTime, getTimeFromStartAndEnde };
 	},
 });
 </script>

--- a/src/components/search/AdditionalInfo.vue
+++ b/src/components/search/AdditionalInfo.vue
@@ -1,0 +1,236 @@
+<template>
+	<div class="extra-features">
+		<button
+			:disabled="fileId?.length > 0 ? false : true"
+			class="thumbnail-button"
+			:title="'See more thumbnails'"
+			@click="showThumbnails()"
+		>
+			<span class="material-icons">photo_library</span>
+		</button>
+	</div>
+	<div
+		ref="extraContentRef"
+		class="extra-content"
+	>
+		<ItemSlider item-class="extra-thumbnail">
+			<template #default="slotProps">
+				<router-link
+					v-for="(item, index) in thumbnailImages"
+					:key="index"
+					:to="{ name: 'Record', params: { id: id }, query: { autoplay: true, startAt: timeStamps[index] / 1000 } }"
+					role="link"
+					class="extra-thumbnail"
+					v-bind="slotProps"
+					:replace="router.currentRoute.value.name === 'Record' ? true : false"
+				>
+					<div
+						ref="thumbnailRefs"
+						class="img-wrap"
+					>
+						<kb-imagecomponent :imagedata="thumbnailImageData[index]"></kb-imagecomponent>
+					</div>
+					<div class="img-stamp">{{ ConvertSecondstoShow(timeStamps[index]) }}</div>
+				</router-link>
+			</template>
+		</ItemSlider>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, onMounted, ref, watch } from 'vue';
+import ItemSlider from '@/components/search/ItemSlider.vue';
+import { APIService } from '@/api/api-service';
+import gsap from 'gsap';
+import { ImageComponentType } from '@/types/ImageComponentType';
+import { useRouter, RouteLocationNormalizedLoaded } from 'vue-router';
+
+export default defineComponent({
+	name: 'AdditionalInfo',
+	components: {
+		ItemSlider,
+	},
+	props: {
+		id: { type: String, required: true },
+		fileId: { type: String, required: true },
+		duration: { type: Number, required: true },
+		open: { type: Boolean },
+	},
+	setup(props) {
+		const thumbnailImages = ref(10);
+		const extraContentShown = ref(false);
+		const thumbnailImageData = ref([] as string[]);
+		const timeStamps = ref([] as number[]);
+
+		const router = useRouter();
+
+		const extraContentRef = ref<HTMLElement | null>(null);
+		const thumbnailRefs = ref<HTMLAnchorElement[]>([]);
+
+		const showThumbnails = () => {
+			extraContentShown.value = !extraContentShown.value;
+			if (props.fileId && extraContentShown.value) {
+				if (thumbnailImageData.value.length === 0) {
+					requestExtraThumbnails();
+				}
+			}
+			if (extraContentShown.value === true) {
+				gsap.set(extraContentRef.value, {
+					visibility: 'visible',
+				});
+			}
+			gsap.to(extraContentRef.value, {
+				height: extraContentShown.value ? 'auto' : '0px',
+				opacity: extraContentShown.value ? '1' : '0',
+				duration: 0.2,
+				onComplete: () => {
+					if (extraContentShown.value === false) {
+						gsap.set(extraContentRef.value, {
+							visibility: 'hidden',
+						});
+					}
+				},
+			});
+		};
+
+		const ConvertSecondstoShow = (milliseconds: number) => {
+			const seconds = Math.floor(milliseconds / 1000); // Convert milliseconds to seconds
+			const hours = Math.floor(seconds / 3600);
+			const minutes = Math.floor((seconds % 3600) / 60);
+			const remainingSeconds = seconds % 60;
+
+			const timeString =
+				hours +
+				':' +
+				(minutes < 10 ? '0' : '') +
+				minutes +
+				':' +
+				(remainingSeconds < 10 ? '0' : '') +
+				Math.round(remainingSeconds);
+			return timeString;
+		};
+
+		const requestExtraThumbnails = () => {
+			APIService.getExtraThumbnails(props.fileId)
+				.then((thumbServiceResponse) => {
+					console.log(thumbServiceResponse);
+
+					const img = new Image();
+					img.src = thumbServiceResponse.data.sprite;
+					img.onload = () => {
+						thumbnailRefs.value.forEach((item) => {
+							item.style.height = img.height + 'px';
+						});
+					};
+
+					thumbnailRefs.value.forEach((item, index) => {
+						const imgData = {} as ImageComponentType;
+						imgData.imgSrc = thumbServiceResponse.data.sprite;
+						imgData.objectPos = `-${200 * index}px 0px`;
+						imgData.imgOption = 'none';
+						thumbnailImageData.value.push(JSON.stringify(imgData));
+						timeStamps.value.push((props.duration / 10) * index);
+					});
+				})
+				//Just in case the service fail - we fail silently and swoop in with the placeholder
+				.catch(() => {
+					//nay
+				});
+		};
+
+		onMounted(() => {
+			watch(
+				() => props.id,
+				(newVal: string, oldVal: string) => {
+					if (newVal !== oldVal) {
+						thumbnailImageData.value = [];
+						extraContentShown.value = false;
+					}
+				},
+			);
+
+			console.log(router.currentRoute.value.name, 'ROUTE BABY');
+
+			if (props.open) {
+				showThumbnails();
+			}
+		});
+
+		return {
+			thumbnailImages,
+			extraContentShown,
+			thumbnailImageData,
+			showThumbnails,
+			extraContentRef,
+			thumbnailRefs,
+			timeStamps,
+			ConvertSecondstoShow,
+			router,
+		};
+	},
+});
+</script>
+<style scoped>
+.extra-features {
+	margin-top: 10px;
+}
+
+.extra-features .material-icons {
+	font-size: 20px;
+}
+
+.thumbnail-button {
+	cursor: pointer;
+	border: 1px solid #002f702a;
+	border-radius: 0px;
+	background-color: transparent;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	color: #002e70;
+	transition: all 0.3s ease-in-out 0s;
+}
+
+.thumbnail-button:hover {
+	border: 1px solid #002e70;
+}
+
+.thumbnail-button:disabled:hover {
+	border: 1px solid #002f702a;
+	cursor: auto;
+}
+
+.thumbnail-button:disabled {
+	color: rgba(180, 180, 180, 1);
+}
+
+.extra-content {
+	height: 0px;
+}
+
+.extra-thumbnail {
+	flex: 0 0 200px;
+	position: relative;
+	z-index: 1;
+	object-fit: none;
+	display: flex;
+	flex-direction: column;
+	pointer-events: all;
+	text-decoration: none;
+	color: #002e70;
+}
+
+.extra-thumbnail.disabled {
+	pointer-events: none;
+}
+
+.extra-thumbnail .img-wrap {
+	margin-bottom: 10px;
+	height: 105px;
+}
+
+.extra-thumbnail .img-stamp {
+	text-align: center;
+	font-size: 12px;
+}
+</style>

--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -76,7 +76,7 @@ export default defineComponent({
 
 		onMounted(() => {
 			window.innerWidth > 800 ? searchResultStore.toggleShowFacets(true) : searchResultStore.toggleShowFacets(false);
-
+			toggleFacets();
 			currentFacets.value = props.facetResults;
 			channelFacets.value = simplifyFacets(currentFacets.value['creator_affiliation']);
 			categoryFacets.value = simplifyFacets(currentFacets.value['categories']);
@@ -99,7 +99,6 @@ export default defineComponent({
 						currentFacetNr.value = searchResultStore.loading ? 10 : Math.min(channelFacets.value.length, 10);
 						categoryNr.value = Number(categoryFacets.value.length);
 						lastUpdate.value = new Date().getTime();
-						showFacets.value = true;
 					}
 				},
 			);
@@ -155,13 +154,6 @@ export default defineComponent({
 	overflow: hidden;
 }
 
-.search-facets.active {
-	visibility: visible;
-	pointer-events: all;
-	transform: translateX(0%);
-	width: 100%;
-}
-
 h2 {
 	font-size: 16px;
 	color: black;
@@ -204,6 +196,12 @@ h2 {
 	box-sizing: border-box;
 	padding: 40px 15% 0px 15%;
 	transform: translateX(-100%);
+}
+.search-facets.active {
+	visibility: visible;
+	pointer-events: all;
+	transform: translateX(0%);
+	width: 100%;
 }
 
 @media (min-width: 640px) {

--- a/src/components/search/ItemSlider.vue
+++ b/src/components/search/ItemSlider.vue
@@ -91,4 +91,8 @@ export default defineComponent({
 .item-slider::-webkit-scrollbar {
 	width: 20px;
 }
+
+.item-slider::-webkit-scrollbar-thumb {
+	background-color: rgb(200, 200, 200);
+}
 </style>

--- a/src/components/search/ItemSlider.vue
+++ b/src/components/search/ItemSlider.vue
@@ -1,0 +1,94 @@
+<template>
+	<div
+		ref="itemSliderRef"
+		:class="move ? 'item-slider active' : 'item-slider'"
+	>
+		<slot :disable-links="move"></slot>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, onMounted, ref } from 'vue';
+
+export default defineComponent({
+	name: 'ItemSlider',
+	props: {
+		itemClass: { type: String, required: true },
+	},
+	setup(props) {
+		const itemSliderRef = ref<HTMLElement | null>(null);
+		const isDown = ref(false);
+		const startX = ref(0);
+		const scrollLeft = ref(0);
+		const linkItems = ref(null as null | NodeList);
+		const move = ref(false);
+
+		onMounted(() => {
+			if (itemSliderRef.value) {
+				linkItems.value = itemSliderRef?.value.querySelectorAll('.' + props.itemClass);
+			}
+			if (itemSliderRef.value) {
+				itemSliderRef.value.addEventListener('mousedown', startAndCalculateOffset);
+				itemSliderRef.value.addEventListener('mouseleave', stopMovementOnParent);
+				itemSliderRef.value.addEventListener('mouseup', stopMovementOnParent);
+				itemSliderRef.value.addEventListener('mousemove', calculateMovement);
+			}
+		});
+		const startAndCalculateOffset = (e: MouseEvent) => {
+			if (itemSliderRef.value) {
+				isDown.value = true;
+				startX.value = e.pageX - itemSliderRef.value.offsetLeft;
+				scrollLeft.value = itemSliderRef.value.scrollLeft;
+			}
+		};
+		const stopMovementOnParent = () => {
+			move.value = false;
+
+			if (itemSliderRef.value) {
+				isDown.value = false;
+			}
+		};
+		const calculateMovement = (e: MouseEvent) => {
+			if (itemSliderRef.value) {
+				if (!isDown.value) {
+					return;
+				}
+				move.value = true;
+				e.preventDefault();
+				const x = e.pageX - itemSliderRef.value.offsetLeft;
+				itemSliderRef.value.scrollLeft = scrollLeft.value - (x - startX.value);
+			}
+		};
+
+		return { itemSliderRef, move };
+	},
+});
+</script>
+<style>
+.item-slider {
+	margin-top: 20px;
+	position: relative;
+	overflow: hidden;
+	display: flex;
+	justify-content: space-evenly;
+	height: 0px;
+	align-items: center;
+	overflow-x: scroll;
+	gap: 5px;
+	width: 100%;
+	height: 100%;
+}
+
+.item-slider::-webkit-scrollbar-track {
+	background-color: rgb(255, 255, 255);
+	margin: -6px;
+}
+
+.item-slider.active a {
+	pointer-events: none;
+}
+
+.item-slider::-webkit-scrollbar {
+	width: 20px;
+}
+</style>

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -124,7 +124,7 @@ export default defineComponent({
 	box-sizing: border-box;
 	width: 100%;
 	border-bottom: 1px solid rgba(150, 150, 150, 0.3);
-	margin-bottom: 40px;
+	margin-bottom: 20px;
 }
 
 .hit-box:first-of-type {
@@ -136,7 +136,7 @@ export default defineComponent({
 	position: absolute;
 	height: 15px;
 	text-align: center;
-	color: rgba(150, 150, 150, 0.3);
+	color: #002e70;
 	background-color: white;
 	transform: translate(-50%, 0);
 	left: 50%;
@@ -150,7 +150,7 @@ export default defineComponent({
 	position: absolute;
 	height: 15px;
 	text-align: center;
-	color: rgba(150, 150, 150, 0.3);
+	color: #002e70;
 	background-color: white;
 	transform: translate(-50%, 0);
 	left: 50%;

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -48,9 +48,7 @@ export default defineComponent({
 		const resultContainer = ref<HTMLElement | null>(null);
 
 		const getDuration = (resultItem: GenericSearchResultType) => {
-			return resultItem
-				? t('record.duration') + ': ' + formatDuration(resultItem.duration, resultItem.startTime, resultItem.endTime, t)
-				: '';
+			return resultItem ? formatDuration(resultItem.duration, resultItem.startTime, resultItem.endTime, t) : '';
 		};
 
 		const getStartTime = (resultItem: GenericSearchResultType) => {
@@ -125,8 +123,40 @@ export default defineComponent({
 	padding: 0 0 10px 0;
 	box-sizing: border-box;
 	width: 100%;
+	border-bottom: 1px solid rgba(150, 150, 150, 0.3);
+	margin-bottom: 40px;
 }
 
+.hit-box:first-of-type {
+	padding-top: 40px;
+	border-top: 1px solid rgba(150, 150, 150, 0.3);
+}
+.hit-box:first-of-type:before {
+	content: '•';
+	position: absolute;
+	height: 15px;
+	text-align: center;
+	color: rgba(150, 150, 150, 0.3);
+	background-color: white;
+	transform: translate(-50%, 0);
+	left: 50%;
+	top: calc(0px - 10px);
+	width: 20px;
+	background-color: white;
+}
+
+.hit-box:after {
+	content: '•';
+	position: absolute;
+	height: 15px;
+	text-align: center;
+	color: rgba(150, 150, 150, 0.3);
+	background-color: white;
+	transform: translate(-50%, 0);
+	left: 50%;
+	width: 20px;
+	background-color: white;
+}
 .search-results {
 	position: relative;
 	max-width: 100%;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -19,6 +19,11 @@ const routes: Array<RouteRecordRaw> = [
 		path: '/record/:id',
 		name: 'Record',
 		component: () => import('../views/ShowRecord.vue'),
+		props: (route) => ({
+			id: route.params.id,
+			autoplay: route.query.autoplay || null,
+			startAt: route.query.startAt || null,
+		}),
 	},
 ];
 

--- a/src/types/GenericSearchResultTypes.ts
+++ b/src/types/GenericSearchResultTypes.ts
@@ -33,7 +33,7 @@ export interface GenericSearchResultType {
 	_version: number;
 	startTime?: string;
 	endTime?: string;
-	duration?: string;
+	duration_ms: string;
 	origin: string;
 }
 

--- a/src/types/ImageComponentType.ts
+++ b/src/types/ImageComponentType.ts
@@ -1,5 +1,6 @@
 export interface ImageComponentType extends HTMLElement {
 	imgOption: string;
+	objectPos: string;
 	imgSrc: string | undefined;
 	imgTitle: string | undefined;
 	altText: string | undefined;

--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -70,6 +70,21 @@ function generateDurationParts(hours: number, minutes: number, seconds: number, 
 	return durationParts;
 }
 
+function getTimeFromStartAndEnde(duration: string) {
+	const match = duration.match(/PT(\d+H)?(\d+M)?(\d+S)?/);
+	if (match) {
+		const hours = parseInt(match[1] || '0');
+		const minutes = parseInt(match[2] || '0');
+		const seconds = parseInt(match[3] || '0');
+
+		const totalMilliseconds = ((hours * 60 + minutes) * 60 + seconds) * 1000;
+
+		return totalMilliseconds;
+	} else {
+		return 0;
+	}
+}
+
 function getBroadcastDate(isoDate: string, locale: string): string {
 	const date = new Date(isoDate);
 
@@ -97,4 +112,4 @@ function getBroadcastTime(isoDate: string): string {
 	return new Intl.DateTimeFormat('en-GB', options).format(dateObj);
 }
 
-export { formatDuration, getBroadcastDate, getBroadcastTime };
+export { formatDuration, getBroadcastDate, getBroadcastTime, getTimeFromStartAndEnde };


### PR DESCRIPTION
This is a POC of getting extra thumbnails into the search results, and under the fullpost player.

Right now, the timestamp of the thumbnail is not an exact match for the right time, but that takes some tinkering with Thomas and the kaltura API to make that work. This PR shows that we can do this nicely tho, and route-link to the right place and start the player at a new starting point.