### PR TITLE
First go at implementing secure cookie flow

### DIFF
--- a/src/api/api-client.ts
+++ b/src/api/api-client.ts
@@ -5,6 +5,7 @@ import {
 	APIMoreLikeThisResponseType,
 	APIAutocompleteResponseType,
 	APIThumbnailsResponseType,
+	APIAuthResponseType,
 } from '@/types/APIResponseTypes';
 
 export function sleep(random?: boolean): Promise<void> {
@@ -103,6 +104,10 @@ export class APIServiceClient {
 	}
 
 	async getThumbnail(id: string): Promise<APIThumbnailsResponseType> {
-		return await this.httpClient.get(`thumbnails/?fileId=${id}&width=200&height=105`);
+		return await this.httpClient.get(`bff/v1/proxy/ds-image/kaltura/thumbnails/?fileId=${id}&width=200&height=105`);
+	}
+
+	async authenticate(): Promise<APIAuthResponseType> {
+		return await this.httpClient.get('bff/v1/authenticate/');
 	}
 }

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -197,6 +197,9 @@
          "generic":"Noget gik galt - vi kan ikke afspille lydfilen i øjeblikket"
       }
    },
+   "auth": {
+      "serviceFailed":"Applikationens bagvedliggende services er ikke tilgængelige i øjeblikket - prøv igen senere"
+   },
    "searchfailed":"Noget gik galt med din søgning",
    "malformeduri": "Noget gik galt med parameterne til din søgning - prøv at ændre din søgeterm"
   } 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -189,7 +189,11 @@
                "playerInit":"The audio player is not available at the moment",
                "generic":"Something went wrong - we can't play this audio clip at the moment"
             }
+            
        },
+       "auth": {
+         "serviceFailed":"The apllication's underlying services are not available at the moment - please try again later"
+      },
    "searchfailed":"The search request could not be performed",
    "malformeduri": "Something went wrong with your search terms - try to change some of them"
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router';
 import { provideErrorManager } from '@/components/global/error-handling/error-manager';
+import { useAuthStore } from '@/store/authStore';
 
 import '@/assets/fonts/iconfont/material-icons.css';
 
@@ -16,4 +17,15 @@ const app = createApp(App).use(router).use(pinia).use(i18n);
 
 //Attach to error manager globally
 provideErrorManager(app);
+
+const authStore = useAuthStore();
+// Wrapped in anonymous async function to avoid top-level 'await' to support older browsers
+(async () => {
+	try {
+		await authStore.authenticate();
+	} catch (error) {
+		console.error('error authenticating', error);
+	}
+})();
+
 app.mount('#app');

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,29 @@
+import { defineStore } from 'pinia';
+import { APIService } from '@/api/api-service';
+import { ErrorManagerType } from '@/types/ErrorManagerType';
+//Had to use the global t function as a work-around here - see comment below
+import i18n from '../i18n';
+import { inject } from 'vue';
+
+export const useAuthStore = defineStore('authStore', () => {
+	const errorManager = inject('errorManager') as ErrorManagerType;
+	/*Had to use the global t function as a work-around here. The reaseon is to
+	 * avoid "message-compiler Must be called at the top of a `setup` function" error
+	 * which comes from importing import { useI18n } from "vue-i18n" and calling
+	 * const { t } = useI18n() so early in the app setup flow.
+	 * It works all other places as the are called/initiated later in the app flow
+	 **/
+	const { t } = i18n.global;
+	const authenticate = async () => {
+		try {
+			await APIService.authenticate();
+		} catch (error) {
+			console.error('Error authenticating:', error);
+			errorManager.submitCustomError('auth-error', t('error.auto.serviceFailed'));
+		}
+	};
+
+	return {
+		authenticate,
+	};
+});

--- a/src/types/APIResponseTypes.ts
+++ b/src/types/APIResponseTypes.ts
@@ -88,3 +88,7 @@ export interface APIResponseHeaderType {
 		queryUUID?: string;
 	};
 }
+
+export interface APIAuthResponseType {
+	resp: string;
+}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -60,6 +60,11 @@ export default ({ mode }) => {
 					rewrite: (path) => path.replace(/^\/ds-api\/thumbnails\//, ''),
 					changeOrigin: true,
 				},
+				'/ds-api/bff/': {
+					target: env.DEVEL_API_BFF,
+					rewrite: (path) => path.replace(/^\/ds-api\/bff\//, ''),
+					changeOrigin: true,
+				},
 			},
 		},
 	});


### PR DESCRIPTION
The very first POC of secure cookie flow. For now this only applies to thumbnail service. So the test is that thumbnails still work on this branch. Remember a fresh conf from Aegis.

Change log: 
Add request for auth cookie at app init
Switch to new proxy endpoint that now handles all thumbnail and authentication requests