### PR TITLE
DRA-821 - background color on autocomplete

### DIFF
--- a/src/components/search/Autocomplete.vue
+++ b/src/components/search/Autocomplete.vue
@@ -188,6 +188,7 @@ export default defineComponent({
 	list-style-type: none;
 	padding: 0px 0px;
 	margin: 0;
+	background-color: white;
 }
 
 .autocomplete button span {
@@ -201,6 +202,7 @@ export default defineComponent({
 	overflow: hidden;
 	text-wrap: nowrap;
 	text-overflow: ellipsis;
+	background-color: white;
 }
 
 .autocomplete ul li:hover,


### PR DESCRIPTION
I'm not quite sure why this was a bug in some way - but I've added the white background color to both the ul list and the li list elements. Now it should be *almost* impossible to have a transparent background, no matter what browser and how it decides to interpret the code. 