### PR TITLE
DRA-915 - spinner needs to go away after failed solr query.

### DIFF
--- a/src/store/searchResultStore.ts
+++ b/src/store/searchResultStore.ts
@@ -202,6 +202,8 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 		} catch (err: unknown) {
 			error.value = (err as AxiosError).message;
 			errorManager.submitError(err as AxiosError, t('error.searchfailed'));
+			noHits.value = numFound.value === 0;
+			loading.value = false;
 		} finally {
 			if (responseMatchesCurrentSearch(comparisonSearchUUID)) {
 				loading.value = false;


### PR DESCRIPTION
This should make sure even if we fail, we sent an error and set the result to zero which promts the no hits page. The error needs redesign, but that's part of a larger task still at Daniels desk.