### PR TITLE
DRA-853: reworked checkbox for channels

### DIFF
--- a/src/components/common/CustomExpander.vue
+++ b/src/components/common/CustomExpander.vue
@@ -5,6 +5,10 @@
 			:icon="icon"
 			:subline="subline"
 			:click="toggleExpander"
+			:open="expanderOpen"
+			:item-array="itemArray"
+			:pass-update="passAlongUpdate"
+			:filter-cuttof="filterNameCutoff"
 		></TimelineHeadline>
 		<div
 			ref="expandContainer"
@@ -28,6 +32,7 @@
 import { defineComponent, onMounted, ref, PropType } from 'vue';
 import gsap from 'gsap';
 import TimelineHeadline from '@/components/common/TimelineHeadline.vue';
+import { SelectorData } from '@/types/TimeSearchTypes';
 
 export default defineComponent({
 	name: 'CustomExpander',
@@ -38,6 +43,13 @@ export default defineComponent({
 		headline: {
 			type: String as PropType<string>,
 			required: true,
+		},
+		filterNameCutoff: {
+			type: Number as PropType<number>,
+			required: false,
+			default() {
+				return 3;
+			},
 		},
 		icon: {
 			type: String as PropType<string>,
@@ -52,11 +64,28 @@ export default defineComponent({
 			required: false,
 			default: false,
 		},
+		itemArray: {
+			type: Array as PropType<SelectorData[]>,
+			required: false,
+			default() {
+				return [] as SelectorData[];
+			},
+		},
+		updateEntity: {
+			type: Function,
+			default() {
+				return null;
+			},
+		},
 	},
 
 	setup(props) {
 		const expanderOpen = ref(false);
 		const expandContainer = ref<HTMLElement | null>(null);
+
+		const passAlongUpdate = (parent: SelectorData[], index: number, val: boolean) => {
+			props.updateEntity(parent, index, val);
+		};
 
 		const toggleExpander = () => {
 			if (expanderOpen.value) {
@@ -99,7 +128,7 @@ export default defineComponent({
 			}
 		});
 
-		return { expanderOpen, toggleExpander, expandContainer };
+		return { expanderOpen, toggleExpander, expandContainer, passAlongUpdate };
 	},
 });
 </script>

--- a/src/components/common/PortalContent.vue
+++ b/src/components/common/PortalContent.vue
@@ -68,6 +68,6 @@ export default defineComponent({
 
 <style>
 .time-search {
-	margin-bottom: 40px;
+	margin-bottom: -70px;
 }
 </style>

--- a/src/components/common/SimpleCheckbox.vue
+++ b/src/components/common/SimpleCheckbox.vue
@@ -1,0 +1,304 @@
+<template>
+	<div class="container">
+		<Transition
+			mode="out-in"
+			name="result"
+		>
+			<div
+				v-if="!loading"
+				class="checkbox-container"
+			>
+				<label
+					:title="title"
+					class="label"
+				>
+					<span class="title">{{ title }}</span>
+					<span class="tag-number">{{ displayAmount(amount) }}</span>
+					<input
+						role="checkbox"
+						tabindex="0"
+						type="checkbox"
+						class="checkbox"
+						:checked="checked"
+						@change="check(fqkey, title)"
+					/>
+				</label>
+			</div>
+			<div
+				v-else
+				class="loading"
+			>
+				<div
+					:style="`animation-delay:${Math.random() * 2}s`"
+					class="shimmer"
+				></div>
+				<div class="name">
+					<span
+						:style="`width:${Math.random() * 15 + 20}px`"
+						class="text"
+					></span>
+					<span
+						:style="`width:${Math.random() * 15 + 20}px`"
+						class="text"
+					></span>
+					<span
+						:style="`width:${Math.random() * 15 + 20}px`"
+						class="text"
+					></span>
+				</div>
+				<label>
+					loading
+					<input
+						disabled
+						role="checkbox"
+						tabindex="0"
+						:checked="checked"
+						type="checkbox"
+						class="checkbox"
+					/>
+				</label>
+			</div>
+		</Transition>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { addFilter, removeFilter, filterExists, createAffiliationFilter } from '@/utils/filter-utils';
+export default defineComponent({
+	name: 'SimpleCheckbox',
+	props: {
+		fqkey: {
+			type: String,
+			required: false,
+			default() {
+				return '';
+			},
+		},
+		title: {
+			type: String,
+			required: false,
+			default() {
+				return '';
+			},
+		},
+		amount: {
+			type: String,
+			required: false,
+			default() {
+				return '';
+			},
+		},
+		checked: { type: Boolean, required: false },
+		loading: { type: Boolean, required: true },
+	},
+	setup() {
+		const router = useRouter();
+		const route = useRoute();
+
+		const check = (key: string | undefined, title: string | undefined) => {
+			if (title && key) {
+				const routeQueries = filterExists(key, title)
+					? removeFilter(route, createAffiliationFilter(title))
+					: addFilter(route, createAffiliationFilter(title));
+				routeQueries.start = 0;
+				router.push({ query: routeQueries });
+			}
+		};
+
+		const displayAmount = (value: string | undefined) => {
+			return value ? `(${value})` : '';
+		};
+
+		return { check, displayAmount };
+	},
+});
+</script>
+
+<style scoped>
+:host {
+	display: block;
+	transition: all 0.3s linear;
+	height: 25px;
+	width: 100%;
+	margin-right: 5px;
+}
+
+.loading {
+	flex-direction: row;
+	height: 25px;
+	justify-content: space-between;
+	display: flex;
+}
+
+.shimmer {
+	animation: loading 3s ease-in-out 0s infinite;
+	background: rgb(255, 255, 255);
+	background: linear-gradient(
+		117deg,
+		rgba(255, 255, 255, 0) 44%,
+		rgba(255, 255, 255, 0.7455357142857143) 64%,
+		rgba(255, 255, 255, 0) 77%
+	);
+	position: absolute;
+	width: 100%;
+	height: 25px;
+	mix-blend-mode: overlay;
+	overflow: hidden;
+	background-size: 200% 100%;
+	background-position: 160% center;
+	opacity: 0.5;
+}
+
+.name {
+	height: 100%;
+	display: flex;
+	gap: 5px;
+}
+
+.loading label {
+	color: transparent;
+	user-select: none;
+}
+
+.loading .name .text {
+	margin: 5px 0px;
+	border-radius: 20px;
+	background-color: rgba(170, 170, 170, 1);
+	height: 12px;
+}
+
+@keyframes loading {
+	0% {
+		background-position: 160% center;
+	}
+	20% {
+		background-position: 160% center;
+	}
+	80% {
+		background-position: -20% center;
+	}
+	100% {
+		background-position: -20% center;
+	}
+}
+
+.checkbox-container {
+	padding: 0px 5px;
+	text-align: left;
+}
+
+.tag-number {
+	font-size: 10px;
+	color: #383838;
+	display: inline-block;
+	padding-left: 5px;
+	vertical-align: bottom;
+	line-height: 24px;
+	height: 100%;
+}
+
+.title {
+	font-size: 14px;
+	text-overflow: ellipsis;
+	max-width: calc(100% - 85px);
+	white-space: nowrap;
+	overflow: hidden;
+	display: inline-block;
+	text-transform: uppercase;
+	color: #002e70;
+}
+
+.loading .checkbox:after {
+	border: 1px solid rgba(170, 170, 170, 1) !important;
+	background-color: rgb(255, 255, 255) !important;
+	cursor: default;
+}
+
+.loading .checkbox:checked:after {
+	background-color: rgba(170, 170, 170, 1) !important;
+}
+
+.loading .checkbox:hover:before {
+	cursor: default !important;
+	border-color: white !important;
+}
+
+.checkbox:disabled {
+	cursor: default;
+}
+
+.checkbox:disabled:hover {
+	cursor: default;
+}
+
+.checkbox:disabled:hover:after {
+	background-color: transparent;
+	cursor: default;
+}
+
+.checkbox:disabled:hover:after {
+	cursor: default;
+	background-color: #002e70;
+}
+
+.checkbox:hover:after {
+	background-color: #caf0fe;
+}
+
+.checkbox:checked:hover:before {
+	border-color: #002e70;
+	cursor: pointer;
+}
+.checkbox:checked:hover:after {
+	border-color: rgba(170, 170, 170, 1);
+	background-color: white;
+}
+
+input:focus {
+	box-shadow: 0 0 0 2px rgba(39, 94, 254, 0.5);
+}
+
+.checkbox {
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	outline: none;
+	position: relative;
+	float: right;
+}
+
+.checkbox:after {
+	cursor: pointer;
+	transition: all 0.15s linear 0s;
+	content: '';
+	display: block;
+	width: 15px;
+	height: 15px;
+	border: 1px solid #002e70;
+}
+
+.checkbox:checked:after {
+	background-color: #002e70;
+}
+
+.checkbox:checked:before {
+	content: '';
+	display: block;
+	width: 7px;
+	height: 12px;
+	border-bottom: 2px solid white;
+	border-right: 2px solid white;
+	position: absolute;
+	top: 1px;
+	left: 5px;
+	box-sizing: border-box;
+	transform-origin: center;
+	transform: rotateZ(45deg);
+}
+
+.label {
+	cursor: pointer;
+	display: block;
+}
+</style>

--- a/src/components/common/SimpleCheckbox.vue
+++ b/src/components/common/SimpleCheckbox.vue
@@ -65,7 +65,13 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { addFilter, removeFilter, filterExists, createAffiliationFilter } from '@/utils/filter-utils';
+import {
+	addChannelFilter,
+	removeChannelFilter,
+	channelFilterExists,
+	createAffiliationFilter,
+} from '@/utils/filter-utils';
+import { useSearchResultStore } from '@/store/searchResultStore';
 export default defineComponent({
 	name: 'SimpleCheckbox',
 	props: {
@@ -90,18 +96,25 @@ export default defineComponent({
 				return '';
 			},
 		},
+		timeSearchActive: {
+			type: Boolean,
+			required: false,
+			default() {
+				return false;
+			},
+		},
 		checked: { type: Boolean, required: false },
 		loading: { type: Boolean, required: true },
 	},
-	setup() {
+	setup(props) {
 		const router = useRouter();
 		const route = useRoute();
-
+		const searchResultStore = useSearchResultStore();
 		const check = (key: string | undefined, title: string | undefined) => {
 			if (title && key) {
-				const routeQueries = filterExists(key, title)
-					? removeFilter(route, createAffiliationFilter(title))
-					: addFilter(route, createAffiliationFilter(title));
+				const routeQueries = channelFilterExists(key, title, searchResultStore.channelFilters)
+					? removeChannelFilter(route, createAffiliationFilter(title), props.timeSearchActive)
+					: addChannelFilter(route, createAffiliationFilter(title), props.timeSearchActive);
 				routeQueries.start = 0;
 				router.push({ query: routeQueries });
 			}

--- a/src/components/common/TimeSearch/DatePicker.vue
+++ b/src/components/common/TimeSearch/DatePicker.vue
@@ -10,7 +10,8 @@
 			text-input
 			:format="format"
 			six-weeks="fair"
-			@update:model-value="newSearch()"
+			:month-change-on-scroll="false"
+			@update:model-value="readyForNewSearch()"
 		></VueDatePicker>
 		<VueDatePicker
 			v-model="endDate"
@@ -22,7 +23,8 @@
 			text-input
 			:format="format"
 			six-weeks="fair"
-			@update:model-value="newSearch()"
+			:month-change-on-scroll="false"
+			@update:model-value="readyForNewSearch()"
 		></VueDatePicker>
 		<div class="from-to-display">
 			<div class="container">
@@ -48,6 +50,7 @@ import '@vuepic/vue-datepicker/dist/main.css';
 import '@/components/common/TimeSearch/custom-datepicker.css';
 import { addDays } from 'date-fns/addDays';
 import { startDate, endDate } from '@/components/common/TimeSearch/TimeSearchInitValues';
+import { useTimeSearchStore } from '@/store/timeSearchStore';
 
 export default defineComponent({
 	name: 'DatePicker',
@@ -56,6 +59,7 @@ export default defineComponent({
 	},
 	emits: ['spanUpdated'],
 	setup(props, { emit }) {
+		const timeSearchStore = useTimeSearchStore();
 		const format = (date: Date) => {
 			const day = date.getDate();
 			const month = date.getMonth() + 1;
@@ -66,6 +70,10 @@ export default defineComponent({
 
 		const newSearch = () => {
 			emit('spanUpdated');
+		};
+
+		const readyForNewSearch = () => {
+			timeSearchStore.setNewSearchReqMet(true);
 		};
 
 		const highlightedDays = computed((): Date[] => {
@@ -84,6 +92,7 @@ export default defineComponent({
 			format,
 			highlightedDays,
 			newSearch,
+			readyForNewSearch,
 		};
 	},
 });

--- a/src/components/common/TimeSearch/TimeSearchFilters.vue
+++ b/src/components/common/TimeSearch/TimeSearchFilters.vue
@@ -74,11 +74,16 @@
 		</CustomExpander>
 	</div>
 	<div class="time-selection">
-		<div class="month-selector-expanding">
+		<div
+			v-if="timeline"
+			class="month-selector-expanding"
+		>
 			<CustomExpander
 				:headline="t('timeSearch.monthHeadline')"
 				icon="event"
 				:subline="getSublineForMonths(months, t)"
+				:item-array="months"
+				:update-entity="updateCheckbox"
 			>
 				<ItemSlider
 					bg-scroll-white="true"
@@ -129,6 +134,8 @@
 					:headline="t('timeSearch.dayHeadline')"
 					icon="date_range"
 					:subline="getSublineForDays(days, t)"
+					:item-array="days"
+					:update-entity="updateCheckbox"
 				>
 					<ItemSlider
 						bg-scroll-white="true"
@@ -172,6 +179,9 @@
 					:headline="t('timeSearch.timeslotHeadline')"
 					icon="schedule"
 					:subline="getSublineForTimeslots(timeslots, t)"
+					:item-array="timeslots"
+					:update-entity="updateCheckbox"
+					:filter-name-cutoff="13"
 				>
 					<ItemSlider
 						bg-scroll-white="true"
@@ -214,6 +224,24 @@
 					</ItemSlider>
 				</CustomExpander>
 			</div>
+		</div>
+		<div
+			v-if="picker"
+			class="apply-time-facets-container"
+		>
+			<button
+				class="close"
+				@click="closeTimeFacets()"
+			>
+				Luk tidspunkter
+			</button>
+			<button
+				class="apply-time-facets"
+				:disabled="!timeSearchStore.newSearchReqMet"
+				@click="emitNewSearch()"
+			>
+				Apply time facets
+			</button>
 		</div>
 	</div>
 </template>
@@ -281,7 +309,7 @@ export default defineComponent({
 			},
 		},
 	},
-	emits: ['newSearch'],
+	emits: ['newSearch', 'close'],
 	setup(props, { emit }) {
 		const { t } = useI18n();
 		const timeSearchStore = useTimeSearchStore();
@@ -318,16 +346,21 @@ export default defineComponent({
 							}
 						});
 						sortedResults.sort((a: dataItem, b: dataItem) => Number(a.year) - Number(b.year));
-						const startYear = Number(sortedResults[0].year);
-						const endYear = Number(sortedResults[sortedResults.length - 1].year);
-						for (let i = startYear; i <= endYear; i++) {
+						timeSearchStore.setStartYear(Number(sortedResults[0].year));
+						timeSearchStore.setEndYear(Number(sortedResults[sortedResults.length - 1].year));
+						for (let i = timeSearchStore.startYear; i <= timeSearchStore.endYear; i++) {
 							selectYears.value.push(i.toString());
 							data.value.push({ key: i, value: i });
 							let item = (sortedResults.find((item) => item.year.includes(i.toString())) as pointItem) || {
 								year: i.toString(),
 								items: 0,
 							};
-							item.x = Number(((100 / (endYear - startYear)) * (i - startYear)).toFixed(2));
+							item.x = Number(
+								(
+									(100 / (timeSearchStore.endYear - timeSearchStore.startYear)) *
+									(i - timeSearchStore.startYear)
+								).toFixed(2),
+							);
 							item.y = item.items;
 							fullYearArray.value.push(item);
 						}
@@ -338,9 +371,7 @@ export default defineComponent({
 					})
 					.catch(() => {
 						//This is purely fallback. We have no data, so we go with what we've set as fallback.
-						let startYear = 1962;
-						let endYear = 2024;
-						for (let i = startYear; i <= endYear; i++) {
+						for (let i = timeSearchStore.startYear; i <= timeSearchStore.endYear; i++) {
 							selectYears.value.push(i.toString());
 							data.value.push({ key: i, value: i });
 						}
@@ -365,6 +396,14 @@ export default defineComponent({
 				}
 				emit('newSearch', false);
 			}
+			if (yearSearch.value) {
+				const resultContainer = document.getElementsByClassName('result-options')[0];
+				resultContainer?.scrollIntoView({
+					behavior: 'smooth',
+					block: 'center',
+				});
+			}
+			timeSearchStore.setNewSearchReqMet(false);
 		};
 
 		const updateStartYear = (val: number) => {
@@ -387,12 +426,22 @@ export default defineComponent({
 			emitNewSearch();
 		};
 
+		const closeTimeFacets = () => {
+			emit('close');
+		};
+
 		const updateCheckbox = (array: SelectorData[], index: number, val: boolean) => {
+			console.log('sup?', array, index, val);
 			array[index].selected = val;
-			emitNewSearch();
+			timeSearchStore.setNewSearchReqMet(true);
+			if (!props.picker) {
+				emitNewSearch();
+			}
 		};
 
 		const updateAllCheckbox = (array: SelectorData[], index: number, val: boolean) => {
+			timeSearchStore.setNewSearchReqMet(true);
+
 			if (val === true) {
 				array.forEach((item) => {
 					item.selected = true;
@@ -406,7 +455,9 @@ export default defineComponent({
 					}
 				});
 			}
-			emitNewSearch();
+			if (!props.picker) {
+				emitNewSearch();
+			}
 		};
 
 		const figuresImage = computed(() => {
@@ -444,6 +495,7 @@ export default defineComponent({
 			dataButton,
 			toggleExplanation,
 			expToggled,
+			closeTimeFacets,
 		};
 	},
 });
@@ -627,7 +679,7 @@ h3 .bold,
 .slider-whiteoff-container:after {
 	right: -1px;
 	left: initial;
-	top: 35px;
+	top: 0px;
 	background: linear-gradient(90deg, rgba(215, 255, 98, 0) 0%, rgb(250, 250, 250) 95%);
 }
 
@@ -871,6 +923,86 @@ h3 .bold,
 
 .picker-background {
 	background-color: #d9f5fe;
+}
+
+.apply-time-facets-container {
+	display: flex;
+	justify-content: center;
+	position: relative;
+	margin-bottom: 30px;
+}
+
+.apply-time-facets {
+	background-color: transparent;
+	cursor: pointer;
+	padding: 5px 7px;
+	font-size: 18px;
+	width: fit-content;
+	display: flex;
+	align-items: center;
+	box-shadow: 1px 1px 2px #00000000;
+	border: 1px solid #d9d8d8;
+	background: #002e70;
+	color: white;
+	border-radius: 4px;
+	transition: all 0s linear 0s;
+	margin-left: 10px;
+	z-index: 1;
+	position: relative;
+	overflow: hidden;
+}
+
+.apply-time-facets:disabled {
+	color: grey;
+	background-color: white;
+}
+
+.apply-time-facets:disabled:after {
+	display: none;
+}
+
+.apply-time-facets:after {
+	transform: translateX(-100%);
+	content: '';
+	display: block;
+	position: absolute;
+	width: 200%;
+	height: 100%;
+	background: linear-gradient(
+		45deg,
+		rgba(255, 255, 255, 0) 10%,
+		rgba(255, 255, 255, 1) 50%,
+		rgba(255, 255, 255, 0) 80%
+	);
+	animation: shine 4s ease-in-out infinite;
+}
+
+@keyframes shine {
+	50% {
+		transform: translateX(-100%);
+		transition-property: opacity, transform;
+	}
+	100% {
+		transform: translateX(200%);
+		transition-property: opacity, transform;
+	}
+}
+
+.close {
+	cursor: pointer;
+	font-size: 18px;
+	width: fit-content;
+	display: flex;
+	align-items: center;
+	box-shadow: 1px 1px 2px #00000000;
+	border: 1px solid #d9d8d8;
+	background: rgb(250, 250, 250);
+	color: #002e70;
+	border-radius: 4px;
+	transition: all 0s linear 0s;
+	position: absolute;
+	left: 0px;
+	padding: 5px 7px;
 }
 
 .data-container {

--- a/src/components/common/TimeSearch/TimeSearchFilters.vue
+++ b/src/components/common/TimeSearch/TimeSearchFilters.vue
@@ -233,14 +233,14 @@
 				class="close"
 				@click="closeTimeFacets()"
 			>
-				Luk tidspunkter
+				{{ t('timeSearch.filterCloseButton') }}
 			</button>
 			<button
 				class="apply-time-facets"
 				:disabled="!timeSearchStore.newSearchReqMet"
 				@click="emitNewSearch()"
 			>
-				Apply time facets
+				{{ t('timeSearch.filterApplyButton') }}
 			</button>
 		</div>
 	</div>
@@ -263,6 +263,8 @@ import {
 	initSliderValues,
 	initStartDate,
 	initEndDate,
+	startYear,
+	endYear,
 } from '@/components/common/TimeSearch/TimeSearchInitValues';
 import { pointItem, markerData, dataItem, SelectorData } from '@/types/TimeSearchTypes';
 import { createSVGCurvedLine } from '@/utils/svg-graph';
@@ -346,9 +348,9 @@ export default defineComponent({
 							}
 						});
 						sortedResults.sort((a: dataItem, b: dataItem) => Number(a.year) - Number(b.year));
-						timeSearchStore.setStartYear(Number(sortedResults[0].year));
-						timeSearchStore.setEndYear(Number(sortedResults[sortedResults.length - 1].year));
-						for (let i = timeSearchStore.startYear; i <= timeSearchStore.endYear; i++) {
+						startYear.value.setFullYear(Number(sortedResults[0].year));
+						endYear.value.setFullYear(Number(sortedResults[sortedResults.length - 1].year));
+						for (let i = startYear.value.getFullYear(); i <= endYear.value.getFullYear(); i++) {
 							selectYears.value.push(i.toString());
 							data.value.push({ key: i, value: i });
 							let item = (sortedResults.find((item) => item.year.includes(i.toString())) as pointItem) || {
@@ -357,8 +359,8 @@ export default defineComponent({
 							};
 							item.x = Number(
 								(
-									(100 / (timeSearchStore.endYear - timeSearchStore.startYear)) *
-									(i - timeSearchStore.startYear)
+									(100 / (endYear.value.getFullYear() - startYear.value.getFullYear())) *
+									(i - startYear.value.getFullYear())
 								).toFixed(2),
 							);
 							item.y = item.items;
@@ -371,7 +373,7 @@ export default defineComponent({
 					})
 					.catch(() => {
 						//This is purely fallback. We have no data, so we go with what we've set as fallback.
-						for (let i = timeSearchStore.startYear; i <= timeSearchStore.endYear; i++) {
+						for (let i = startYear.value.getFullYear(); i <= endYear.value.getFullYear(); i++) {
 							selectYears.value.push(i.toString());
 							data.value.push({ key: i, value: i });
 						}
@@ -431,7 +433,6 @@ export default defineComponent({
 		};
 
 		const updateCheckbox = (array: SelectorData[], index: number, val: boolean) => {
-			console.log('sup?', array, index, val);
 			array[index].selected = val;
 			timeSearchStore.setNewSearchReqMet(true);
 			if (!props.picker) {
@@ -442,7 +443,7 @@ export default defineComponent({
 		const updateAllCheckbox = (array: SelectorData[], index: number, val: boolean) => {
 			timeSearchStore.setNewSearchReqMet(true);
 
-			if (val === true) {
+			if (val) {
 				array.forEach((item) => {
 					item.selected = true;
 				});

--- a/src/components/common/TimeSearch/TimeSearchInitValues.ts
+++ b/src/components/common/TimeSearch/TimeSearchInitValues.ts
@@ -10,34 +10,34 @@ const startDate = ref<Date>(initStartDate.value); // January 1, 1992, 00:00:00
 const endDate = ref<Date>(initEndDate.value); // December 31, 1992, 23:59:59
 
 const days = ref<SelectorData[]>([
-	{ name: 'timeSearch.weekdays.monday', value: 'Monday', selected: false },
-	{ name: 'timeSearch.weekdays.tuesday', value: 'Tuesday', selected: false },
-	{ name: 'timeSearch.weekdays.wednesday', value: 'Wednesday', selected: false },
-	{ name: 'timeSearch.weekdays.thursday', value: 'Thursday', selected: false },
-	{ name: 'timeSearch.weekdays.friday', value: 'Friday', selected: false },
-	{ name: 'timeSearch.weekdays.saturday', value: 'Saturday', selected: false },
-	{ name: 'timeSearch.weekdays.sunday', value: 'Sunday', selected: false },
+	{ name: 'timeSearch.weekdays.monday', value: 'Monday', selected: false, index: 0 },
+	{ name: 'timeSearch.weekdays.tuesday', value: 'Tuesday', selected: false, index: 1 },
+	{ name: 'timeSearch.weekdays.wednesday', value: 'Wednesday', selected: false, index: 2 },
+	{ name: 'timeSearch.weekdays.thursday', value: 'Thursday', selected: false, index: 3 },
+	{ name: 'timeSearch.weekdays.friday', value: 'Friday', selected: false, index: 4 },
+	{ name: 'timeSearch.weekdays.saturday', value: 'Saturday', selected: false, index: 5 },
+	{ name: 'timeSearch.weekdays.sunday', value: 'Sunday', selected: false, index: 6 },
 ]);
 const timeslots = ref<SelectorData[]>([
-	{ name: 'timeSearch.timeslots.morning', value: '[6 TO 12]', selected: false },
-	{ name: 'timeSearch.timeslots.midday', value: '[12 TO 18]', selected: false },
-	{ name: 'timeSearch.timeslots.evening', value: '[18 TO 24]', selected: false },
-	{ name: 'timeSearch.timeslots.night', value: '[0 TO 6]', selected: false },
+	{ name: 'timeSearch.timeslots.morning', value: '[6 TO 12]', selected: false, index: 0 },
+	{ name: 'timeSearch.timeslots.midday', value: '[12 TO 18]', selected: false, index: 1 },
+	{ name: 'timeSearch.timeslots.evening', value: '[18 TO 24]', selected: false, index: 2 },
+	{ name: 'timeSearch.timeslots.night', value: '[0 TO 6]', selected: false, index: 3 },
 ]);
 
 const months = ref<SelectorData[]>([
-	{ name: 'timeSearch.months.january', value: '1', selected: false },
-	{ name: 'timeSearch.months.february', value: '2', selected: false },
-	{ name: 'timeSearch.months.march', value: '3', selected: false },
-	{ name: 'timeSearch.months.april', value: '4', selected: false },
-	{ name: 'timeSearch.months.may', value: '5', selected: false },
-	{ name: 'timeSearch.months.june', value: '6', selected: false },
-	{ name: 'timeSearch.months.july', value: '7', selected: false },
-	{ name: 'timeSearch.months.august', value: '8', selected: false },
-	{ name: 'timeSearch.months.september', value: '9', selected: false },
-	{ name: 'timeSearch.months.october', value: '10', selected: false },
-	{ name: 'timeSearch.months.november', value: '11', selected: false },
-	{ name: 'timeSearch.months.december', value: '12', selected: false },
+	{ name: 'timeSearch.months.january', value: '1', selected: false, index: 0 },
+	{ name: 'timeSearch.months.february', value: '2', selected: false, index: 1 },
+	{ name: 'timeSearch.months.march', value: '3', selected: false, index: 2 },
+	{ name: 'timeSearch.months.april', value: '4', selected: false, index: 3 },
+	{ name: 'timeSearch.months.may', value: '5', selected: false, index: 4 },
+	{ name: 'timeSearch.months.june', value: '6', selected: false, index: 5 },
+	{ name: 'timeSearch.months.july', value: '7', selected: false, index: 6 },
+	{ name: 'timeSearch.months.august', value: '8', selected: false, index: 7 },
+	{ name: 'timeSearch.months.september', value: '9', selected: false, index: 8 },
+	{ name: 'timeSearch.months.october', value: '10', selected: false, index: 9 },
+	{ name: 'timeSearch.months.november', value: '11', selected: false, index: 10 },
+	{ name: 'timeSearch.months.december', value: '12', selected: false, index: 11 },
 ]);
 
 export { timeSliderValues, months, days, timeslots, startDate, endDate, initSliderValues, initEndDate, initStartDate };

--- a/src/components/common/TimeSearch/TimeSearchInitValues.ts
+++ b/src/components/common/TimeSearch/TimeSearchInitValues.ts
@@ -9,6 +9,10 @@ const timeSliderValues = ref<number[]>(initSliderValues.value);
 const startDate = ref<Date>(initStartDate.value); // January 1, 1992, 00:00:00
 const endDate = ref<Date>(initEndDate.value); // December 31, 1992, 23:59:59
 
+/* these are just the preset values. Should be updated when we got the new repo */
+const startYear = ref<Date>(new Date(1921, 0, 1, 0, 0, 0));
+const endYear = ref<Date>(new Date(2022, 11, 31, 23, 59, 59));
+
 const days = ref<SelectorData[]>([
 	{ name: 'timeSearch.weekdays.monday', value: 'Monday', selected: false, index: 0 },
 	{ name: 'timeSearch.weekdays.tuesday', value: 'Tuesday', selected: false, index: 1 },
@@ -40,4 +44,16 @@ const months = ref<SelectorData[]>([
 	{ name: 'timeSearch.months.december', value: '12', selected: false, index: 11 },
 ]);
 
-export { timeSliderValues, months, days, timeslots, startDate, endDate, initSliderValues, initEndDate, initStartDate };
+export {
+	timeSliderValues,
+	months,
+	days,
+	timeslots,
+	startDate,
+	endDate,
+	initSliderValues,
+	initEndDate,
+	initStartDate,
+	startYear,
+	endYear,
+};

--- a/src/components/common/TimeSearchComponent.vue
+++ b/src/components/common/TimeSearchComponent.vue
@@ -130,7 +130,6 @@ export default defineComponent({
 		);
 
 		const updateLink = () => {
-			console.log('link update!');
 			const dayString = days.value
 				.filter((day: SelectorData) => day.selected)
 				.map((day: SelectorData) => day.value)

--- a/src/components/common/TimelineHeadline.vue
+++ b/src/components/common/TimelineHeadline.vue
@@ -94,6 +94,10 @@ export default defineComponent({
 		};
 
 		const formatStringForTime = (val: string) => {
+			/* 
+			if our cutoff is set to 13, we remove the .00 after the numbers, so we just get 13 - 14.
+			This is because of space issues in the design - this was the best way to solve this nicely.
+			*/
 			if (props.filterCuttof === 13) {
 				return val.replace(/.00/g, '');
 			} else {

--- a/src/components/common/TimelineHeadline.vue
+++ b/src/components/common/TimelineHeadline.vue
@@ -1,28 +1,41 @@
 <template>
-	<div class="headline-container">
-		<div
-			class="material-icons icon"
-			@click="dispatchClick()"
-		>
+	<div
+		:class="open ? 'headline-container open' : 'headline-container'"
+		@click="dispatchClick()"
+	>
+		<div class="material-icons icon">
 			{{ icon }}
 		</div>
-		<div
-			class="headline"
-			@click="dispatchClick()"
-		>
+		<div class="headline">
 			<h3>{{ headline }}</h3>
 			<span>{{ subline }}</span>
+		</div>
+		<div class="selected-items">
+			<button
+				v-for="(item, index) in selectedItems"
+				:key="`${index}-${item.name}`"
+				class="selected-entity"
+				@click="handleTimeFacetRemoval(item.index, $event)"
+			>
+				<span class="entity-name">{{ formatStringForTime(t(item.name).substring(0, filterCuttof)) }}</span>
+				<span class="close">×</span>
+			</button>
 		</div>
 	</div>
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue';
+import { defineComponent, PropType, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { SelectorData } from '@/types/TimeSearchTypes';
 
 export default defineComponent({
-	name: 'Duration',
+	name: 'TimelineHeadline',
 	props: {
+		open: {
+			type: Boolean as PropType<boolean>,
+			required: true,
+		},
 		headline: {
 			type: String as PropType<string>,
 			required: true,
@@ -41,6 +54,26 @@ export default defineComponent({
 				return null;
 			},
 		},
+		itemArray: {
+			type: Array as PropType<SelectorData[]>,
+			required: false,
+			default() {
+				return [] as SelectorData[];
+			},
+		},
+		passUpdate: {
+			type: Function,
+			default() {
+				return null;
+			},
+		},
+		filterCuttof: {
+			type: Number as PropType<number>,
+			required: false,
+			default() {
+				return 3;
+			},
+		},
 	},
 
 	setup(props) {
@@ -50,7 +83,25 @@ export default defineComponent({
 			props.click !== undefined ? props.click() : null;
 		};
 
-		return { t, dispatchClick };
+		const selectedItems = computed(() => {
+			return props.itemArray.filter((item: SelectorData) => item.selected);
+		});
+
+		const handleTimeFacetRemoval = (index: number, e: Event) => {
+			e.stopPropagation();
+			props.passUpdate(props.itemArray, index, false);
+			console.log('headline part', index);
+		};
+
+		const formatStringForTime = (val: string) => {
+			if (props.filterCuttof === 13) {
+				return val.replace(/.00/g, '');
+			} else {
+				return val;
+			}
+		};
+
+		return { t, dispatchClick, selectedItems, handleTimeFacetRemoval, formatStringForTime };
 	},
 });
 </script>
@@ -75,7 +126,7 @@ h3 {
 	height: auto;
 }
 
-span {
+.headline span {
 	padding: 0;
 	margin: 0;
 	height: 20px;
@@ -96,23 +147,66 @@ span {
 	gap: 0px;
 }
 
-.subline {
-}
-
 .headline-container {
 	display: flex;
 	justify-content: flex-start;
 	flex-wrap: wrap;
 	flex-direction: row;
-	align-items: center;
-	align-content: center;
-	height: 65px;
+	align-content: flex-start;
+	height: 50px;
 	width: 100%;
+	transition: all 0.15s linear 0s;
+	align-items: flex-start;
+	padding-top: 5px;
+	flex-wrap: nowrap;
+}
+
+.headline-container.open:hover {
+	cursor: pointer;
+	height: 50px !important;
+}
+
+.headline-container:hover {
+	cursor: pointer;
+	height: 55px;
 }
 
 .headline-container h3,
 .headline-container span,
 .headline-container div {
 	cursor: pointer;
+}
+
+.selected-items {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	margin-left: auto;
+	max-width: 40%;
+	gap: 5px;
+	justify-content: flex-end;
+}
+
+.selected-entity {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	border: 0px;
+	border-radius: 15px;
+	background-color: #002e70;
+	color: white;
+	cursor: pointer;
+	position: relative;
+	z-index: 5;
+	white-space: pre;
+}
+
+.selected-entity .entity-name {
+	text-transform: capitalize;
+	padding-right: 5px;
+}
+
+.selected-entity .close {
+	font-size: 20px;
 }
 </style>

--- a/src/components/global/content-elements/EdgedContentArea.vue
+++ b/src/components/global/content-elements/EdgedContentArea.vue
@@ -97,7 +97,6 @@ temporary styling until patterns from design system are implemented
 	align-items: center;
 	padding: 50px 0px;
 	flex-direction: column;
-	margin-bottom: -125px;
 }
 
 .top-dotted-border {

--- a/src/components/search/CategoryTags.vue
+++ b/src/components/search/CategoryTags.vue
@@ -8,7 +8,8 @@
 						ref="listItems"
 						:key="index + 'category'"
 						:class="
-							filterExists('categories', categoryFacets[index]?.title) && !searchResultStore.loading
+							filterExists('categories', categoryFacets[index]?.title, searchResultStore.filters) &&
+							!searchResultStore.loading
 								? 'tag active'
 								: 'tag'
 						"
@@ -21,7 +22,7 @@
 								query: {
 									q: searchResultStore.currentQuery,
 									start: 0,
-									fq: filterExists('categories', categoryFacets[index]?.title)
+									fq: filterExists('categories', categoryFacets[index]?.title, searchResultStore.filters)
 										? removeFilter(route, createTagFilter(categoryFacets[index]?.title)).fq
 										: addFilter(route, createTagFilter(categoryFacets[index]?.title)).fq,
 								},

--- a/src/components/search/Checkbox.vue
+++ b/src/components/search/Checkbox.vue
@@ -66,6 +66,8 @@
 import { defineComponent } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { addFilter, removeFilter, filterExists, createAffiliationFilter } from '@/utils/filter-utils';
+import { useSearchResultStore } from '@/store/searchResultStore';
+
 export default defineComponent({
 	name: 'Checkbox',
 	props: {
@@ -96,10 +98,10 @@ export default defineComponent({
 	setup() {
 		const router = useRouter();
 		const route = useRoute();
-
+		const searchResultStore = useSearchResultStore();
 		const check = (key: string | undefined, title: string | undefined) => {
 			if (title && key) {
-				const routeQueries = filterExists(key, title)
+				const routeQueries = filterExists(key, title, searchResultStore.filters)
 					? removeFilter(route, createAffiliationFilter(title))
 					: addFilter(route, createAffiliationFilter(title));
 				routeQueries.start = 0;

--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -65,7 +65,7 @@
 										:key="index + 'facet'"
 										class="checkbox"
 									>
-										<Checkbox
+										<SimpleCheckbox
 											:fqkey="'creator_affiliation_facet'"
 											:title="channelFacets[index]?.title"
 											:amount="channelFacets[index]?.number.toString()"
@@ -89,7 +89,7 @@ import { useSearchResultStore } from '@/store/searchResultStore';
 import { FacetResultType } from '@/types/GenericSearchResultTypes';
 import { LocationQueryRaw, useRoute, useRouter } from 'vue-router';
 import TimeSearchFilters from '../common/TimeSearch/TimeSearchFilters.vue';
-import Checkbox from '@/components/search/Checkbox.vue';
+import SimpleCheckbox from '@/components/common/SimpleCheckbox.vue';
 import { filterExists, simplifyFacets } from '@/utils/filter-utils';
 import { SelectorData } from '@/types/TimeSearchTypes';
 import { FacetPair } from '@/types/GenericRecordTypes';
@@ -102,7 +102,7 @@ import CustomExpander from '@/components/common/CustomExpander.vue';
 export default defineComponent({
 	name: 'Facets',
 	components: {
-		Checkbox,
+		SimpleCheckbox,
 		TimeSearchFilters,
 		EdgedContentArea,
 		CustomExpander,
@@ -400,7 +400,7 @@ h2 {
 }
 
 .checkbox {
-	padding: 3px 5px;
+	padding: 5px 15px;
 	flex: 0 0 25%;
 	box-sizing: border-box;
 }

--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -16,7 +16,7 @@
 					>
 						<span class="material-icons first">today</span>
 						<span class="material-icons second">schedule</span>
-						Tidspunkter
+						{{ t('timeSearch.filterOpenButton') }}
 						<span :class="timeFacetsOpen ? 'dark-bar open' : 'dark-bar closed'">
 							<span class="dot">
 								<TransitionGroup>

--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -16,7 +16,7 @@
 					>
 						<span class="material-icons first">today</span>
 						<span class="material-icons second">schedule</span>
-						Dato og tid
+						Tidspunkter
 						<span :class="timeFacetsOpen ? 'dark-bar open' : 'dark-bar closed'">
 							<span class="dot">
 								<TransitionGroup>
@@ -32,12 +32,6 @@
 							</span>
 						</span>
 					</button>
-					<button
-						class="reset"
-						@click="resetFilters()"
-					>
-						Ryd filtre
-					</button>
 				</div>
 				<div
 					ref="timeFacets"
@@ -48,6 +42,7 @@
 						:picker="true"
 						:init="false"
 						@new-search="newSearch(true)"
+						@close="toggleTimeFacets()"
 					></TimeSearchFilters>
 				</div>
 				<div class="facet-container">
@@ -61,7 +56,7 @@
 							<div class="facet-options">
 								<TransitionGroup name="result">
 									<div
-										v-for="(singleFacet, index) in currentFacetNr as unknown as FacetPair[]"
+										v-for="(singleFacet, index) in currentChannelNr as unknown as FacetPair[]"
 										:key="index + 'facet'"
 										class="checkbox"
 									>
@@ -69,8 +64,15 @@
 											:fqkey="'creator_affiliation_facet'"
 											:title="channelFacets[index]?.title"
 											:amount="channelFacets[index]?.number.toString()"
-											:checked="filterExists('creator_affiliation_facet', channelFacets[index]?.title)"
-											:loading="searchResultStore.loading"
+											:time-search-active="timeFacetsOpen"
+											:checked="
+												channelFilterExists(
+													'creator_affiliation_facet',
+													channelFacets[index]?.title,
+													searchResultStore.channelFilters,
+												)
+											"
+											:loading="searchResultStore.loading && !searchResultStore.keepFacets"
 										/>
 									</div>
 								</TransitionGroup>
@@ -86,18 +88,20 @@
 <script lang="ts">
 import { defineComponent, PropType, onMounted, ref, watch } from 'vue';
 import { useSearchResultStore } from '@/store/searchResultStore';
+import { useTimeSearchStore } from '@/store/timeSearchStore';
 import { FacetResultType } from '@/types/GenericSearchResultTypes';
-import { LocationQueryRaw, useRoute, useRouter } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import TimeSearchFilters from '../common/TimeSearch/TimeSearchFilters.vue';
 import SimpleCheckbox from '@/components/common/SimpleCheckbox.vue';
-import { filterExists, simplifyFacets } from '@/utils/filter-utils';
+import { channelFilterExists, simplifyFacets, cloneRouteQuery } from '@/utils/filter-utils';
 import { SelectorData } from '@/types/TimeSearchTypes';
 import { FacetPair } from '@/types/GenericRecordTypes';
 import { useI18n } from 'vue-i18n';
 import gsap from 'gsap';
-import { months, days, timeslots, startDate, endDate } from '@/components/common/TimeSearch/TimeSearchInitValues';
+import { days, timeslots, startDate, endDate } from '@/components/common/TimeSearch/TimeSearchInitValues';
 import EdgedContentArea from '@/components/global/content-elements/EdgedContentArea.vue';
 import CustomExpander from '@/components/common/CustomExpander.vue';
+import { removeTimeFacetsFromRoute, normalizeFq } from '@/utils/filter-utils';
 
 export default defineComponent({
 	name: 'Facets',
@@ -114,8 +118,9 @@ export default defineComponent({
 
 	setup(props) {
 		const searchResultStore = useSearchResultStore();
+		const timeSearchStore = useTimeSearchStore();
 		const currentFacets = ref(Object as unknown as FacetResultType);
-		const currentFacetNr = ref(16);
+		const currentChannelNr = ref(16);
 		const channelFacets = ref([] as FacetPair[]);
 		const categoryFacets = ref([] as FacetPair[]);
 		const categoryNr = ref(0);
@@ -132,7 +137,7 @@ export default defineComponent({
 			currentFacets.value = props.facetResults;
 			channelFacets.value = simplifyFacets(currentFacets.value['creator_affiliation_facet']);
 			categoryFacets.value = simplifyFacets(currentFacets.value['categories']);
-			currentFacetNr.value = channelFacets.value.length ? Math.min(channelFacets.value.length, 16) : 16;
+			currentChannelNr.value = channelFacets.value.length ? channelFacets.value.length : 16;
 			categoryNr.value = categoryFacets.value.length ? Number(categoryFacets.value.length) : 0;
 
 			watch(
@@ -142,11 +147,10 @@ export default defineComponent({
 						currentFacets.value = {} as FacetResultType;
 						channelFacets.value = [] as FacetPair[];
 						categoryFacets.value = [] as FacetPair[];
-
 						currentFacets.value = newFacets;
 						channelFacets.value = simplifyFacets(newFacets['creator_affiliation_facet']);
 						categoryFacets.value = simplifyFacets(newFacets['categories']);
-						currentFacetNr.value = searchResultStore.loading ? 16 : Math.min(channelFacets.value.length, 16);
+						currentChannelNr.value = searchResultStore.loading ? 16 : channelFacets.value.length;
 						categoryNr.value = Number(categoryFacets.value.length);
 						lastUpdate.value = new Date().getTime();
 					}
@@ -161,27 +165,13 @@ export default defineComponent({
 			},
 		);
 
-		const resetFilters = () => {
-			router.push({
-				name: 'Home',
-				query: { q: searchResultStore.currentQuery },
-			});
-		};
-
 		const newSearch = (yearSearch: boolean) => {
-			let query: LocationQueryRaw = {
-				q: searchResultStore.currentQuery,
-				start: 0,
-				sort: yearSearch ? 'startTime asc' : '',
-			};
+			const routeQueries = cloneRouteQuery(route);
+			routeQueries.start = 0;
+			routeQueries.sort = yearSearch ? 'startTime asc' : '';
 			const dayString = days.value
 				.filter((day: SelectorData) => day.selected)
 				.map((day: SelectorData) => day.value)
-				.join(' OR ');
-
-			const monthString = months.value
-				.filter((month: SelectorData) => month.selected)
-				.map((month: SelectorData) => month.value)
 				.join(' OR ');
 
 			const timeslotString = timeslots.value
@@ -189,27 +179,30 @@ export default defineComponent({
 				.map((timeslot: SelectorData) => timeslot.value)
 				.join(' OR ');
 
-			const fqArray = [];
+			if (!routeQueries.fq) {
+				routeQueries.fq = [];
+			}
+
+			const existingFq = removeTimeFacetsFromRoute(normalizeFq(routeQueries.fq));
 
 			if (yearSearch) {
-				fqArray.push(
+				existingFq.push(
 					encodeURIComponent(`startTime:[${startDate.value.toISOString() + ' TO ' + endDate.value.toISOString()}]`),
 				);
 			}
-			dayString !== '' ? fqArray.push(encodeURIComponent(`temporal_start_day_da:(${dayString})`)) : null;
-			monthString !== '' ? fqArray.push(encodeURIComponent(`temporal_start_month:(${monthString})`)) : null;
-			timeslotString !== '' ? fqArray.push(encodeURIComponent(`temporal_start_hour_da:(${timeslotString})`)) : null;
+			dayString !== '' ? existingFq.push(encodeURIComponent(`temporal_start_day_da:(${dayString})`)) : null;
+			timeslotString !== '' ? existingFq.push(encodeURIComponent(`temporal_start_hour_da:(${timeslotString})`)) : null;
 
-			(query.fq = fqArray),
-				router.push({
-					name: 'Home',
-					query: query,
-				});
+			routeQueries.fq = existingFq;
+
+			router.push({
+				name: 'Home',
+				query: routeQueries,
+			});
 		};
 
 		const toggleTimeFacets = () => {
 			if (timeFacetsOpen.value) {
-				console.log(timeFacets.value);
 				timeFacetButton.value?.setAttribute('aria-checked', 'false');
 				gsap.to(timeFacets.value, {
 					height: '0px',
@@ -221,8 +214,16 @@ export default defineComponent({
 						});
 					},
 				});
+				const routeQueries = cloneRouteQuery(route);
+				const existingFq = removeTimeFacetsFromRoute(normalizeFq(routeQueries.fq));
+				routeQueries.fq = existingFq;
+				router.push({
+					name: 'Home',
+					query: routeQueries,
+				});
 			} else {
 				timeFacetButton.value?.setAttribute('aria-checked', 'true');
+				timeSearchStore.setNewSearchReqMet(true);
 				gsap.set(timeFacets.value, {
 					display: 'flex',
 					flexDirection: 'column',
@@ -245,6 +246,7 @@ export default defineComponent({
 					duration: 0.5,
 					overwrite: true,
 					opacity: 0,
+					marginBottom: '0px',
 					onComplete: () => {
 						gsap.set(facetsContainer.value, {
 							display: 'none',
@@ -257,6 +259,7 @@ export default defineComponent({
 					onComplete: () => {
 						gsap.to(facetsContainer.value, {
 							height: 'auto',
+							marginBottom: '-125px',
 							duration: 0.5,
 							opacity: 1,
 							overwrite: true,
@@ -270,9 +273,9 @@ export default defineComponent({
 			currentFacets,
 			lastUpdate,
 			searchResultStore,
-			filterExists,
+			channelFilterExists,
 			simplifyFacets,
-			currentFacetNr,
+			currentChannelNr,
 			channelFacets,
 			categoryFacets,
 			categoryNr,
@@ -284,7 +287,6 @@ export default defineComponent({
 			timeFacetsOpen,
 			newSearch,
 			timeFacetButton,
-			resetFilters,
 			t,
 		};
 	},
@@ -309,6 +311,7 @@ export default defineComponent({
 	display: none;
 	height: 0px;
 	overflow: hidden;
+	position: relative;
 }
 
 .time-facets-toggle {
@@ -358,7 +361,7 @@ export default defineComponent({
 	flex-direction: row;
 	gap: 20px;
 	box-sizing: border-box;
-	padding: 10px 5px;
+	padding: 0px 5px;
 }
 
 .facet-options {
@@ -382,21 +385,6 @@ h2 {
 }
 .facet-box:empty {
 	display: none;
-}
-
-.reset {
-	cursor: pointer;
-	padding: 3px 3px;
-	font-size: 20px;
-	width: fit-content;
-	display: flex;
-	align-items: center;
-	box-shadow: 1px 1px 2px rgba(0, 0, 0, 0);
-	border: 1px solid #d9d8d8;
-	background: #ffffff;
-	color: #002e70;
-	border-radius: 4px;
-	transition: all 0s linear 0s;
 }
 
 .checkbox {

--- a/src/components/search/SearchOverhead.vue
+++ b/src/components/search/SearchOverhead.vue
@@ -176,18 +176,12 @@ export default defineComponent({
 			}
 			searchResultStore.preliminaryFilter = val;
 			searchResultStore.resetAutocomplete();
-			let query: LocationQueryRaw = {
-				q: searchResultStore.currentQuery,
-				start: 0,
-			};
-			if (searchResultStore.preliminaryFilter !== '') {
-				query.fq = searchResultStore.preliminaryFilter;
-			}
-			if (searchResultStore.sort !== '') {
-				query.sort = searchResultStore.sort;
-			} else {
-				query.sort = encodeURIComponent(`score desc`);
-			}
+			const query = { ...route.query };
+			console.log(route.query);
+			let filters = [] as string[];
+			query.fq !== undefined ? (filters = [...(query.fq as string[])]) : null;
+			filters = filters.filter((str) => !str.includes('origin'));
+			query.fq = filters;
 
 			router.push({
 				name: 'Home',

--- a/src/components/search/SearchOverhead.vue
+++ b/src/components/search/SearchOverhead.vue
@@ -77,7 +77,6 @@
 							:query="searchResultStore.lastSearchQuery !== undefined ? searchResultStore.lastSearchQuery : ''"
 						/>
 					</div>
-					<!-- <Sort v-if="searchResultStore.searchResult.length > 0" /> -->
 				</div>
 				<div class="sort-options">
 					<Sort></Sort>

--- a/src/components/search/SearchOverhead.vue
+++ b/src/components/search/SearchOverhead.vue
@@ -2,30 +2,29 @@
 	<div class="container">
 		<div class="row">
 			<div class="hit-count">
-				<div class="result-options">
-					<div class="hits">
-						<HitCount
-							:hit-count="searchResultStore.numFound"
-							:no-hits="searchResultStore.noHits"
-							:query="searchResultStore.lastSearchQuery !== undefined ? searchResultStore.lastSearchQuery : ''"
-						/>
-					</div>
-					<!-- <Sort v-if="searchResultStore.searchResult.length > 0" /> -->
-				</div>
 				<div :class="!searchResultStore.loading ? 'filter-options' : 'filter-options disabled'">
-					<button
-						v-if="searchResultStore.searchResult.length > 0"
-						ref="toggleFacetsButton"
-						role="switch"
-						aria-checked="true"
-						class="filter-button"
-						@click="toggleFacets()"
-					>
-						<span class="material-icons">tune</span>
-						<span class="filter-button-text">
-							{{ searchResultStore.showFacets ? $t('search.hideFilters') : $t('search.showFilters') }}
-						</span>
-					</button>
+					<div class="filter-buttons">
+						<button
+							ref="toggleFacetsButton"
+							role="switch"
+							aria-checked="true"
+							class="filter-button"
+							@click="toggleFacets()"
+						>
+							<span class="material-icons">tune</span>
+							<span class="filter-button-text">
+								{{ searchResultStore.showFacets ? $t('search.hideFilters') : $t('search.showFilters') }}
+							</span>
+						</button>
+						<button
+							v-if="searchResultStore.filters.length > 0 || searchResultStore.channelFilters.length > 0"
+							class="reset"
+							@click="resetFilters()"
+						>
+							<span>×</span>
+							Reset filtre
+						</button>
+					</div>
 					<button
 						:class="tvToggled ? 'source-facet-button open' : 'source-facet-button'"
 						@click="toggleTV($event)"
@@ -70,6 +69,16 @@
 					</button>
 				</div>
 				<Facets :facet-results="searchResultStore.facetResult" />
+				<div class="result-options">
+					<div class="hits">
+						<HitCount
+							:hit-count="searchResultStore.numFound"
+							:no-hits="searchResultStore.noHits"
+							:query="searchResultStore.lastSearchQuery !== undefined ? searchResultStore.lastSearchQuery : ''"
+						/>
+					</div>
+					<!-- <Sort v-if="searchResultStore.searchResult.length > 0" /> -->
+				</div>
 				<div class="sort-options">
 					<Sort></Sort>
 					<div class="search-options">
@@ -124,12 +133,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, onMounted } from 'vue';
+import { defineComponent, ref, onMounted, watch } from 'vue';
 import { useSearchResultStore } from '@/store/searchResultStore';
-import { useRoute, useRouter, LocationQueryRaw } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import Facets from '@/components/search/Facets.vue';
-
+import { cloneRouteQuery, normalizeFq } from '@/utils/filter-utils';
 import Sort from './Sort.vue';
 import HitCount from './HitCount.vue';
 
@@ -163,10 +172,41 @@ export default defineComponent({
 			searchResultStore.showFacets = false;
 		});
 
+		watch(
+			() => route.query.fq,
+			(newFq) => {
+				/* 
+				we have to do this, because vue acts weird here.
+				when we have normal route changes, it seems like we get an array here,
+				but when we use brower back and forth buttons, we get strings, IF there is only one filter.
+				Weird and breaking behavior, that we have to account for here.
+				*/
+				const normalizedFq: string[] = Array.isArray(newFq) ? (newFq as string[]) : newFq ? [newFq as string] : [];
+				const originFilter = normalizedFq.find((fq: string) => fq.includes('origin'));
+				if (originFilter) {
+					if (decodeURIComponent(originFilter) === delimitationOptions.radio) {
+						tvToggled.value = false;
+					} else if (decodeURIComponent(originFilter) === delimitationOptions.tv) {
+						radioToggled.value = false;
+					}
+				}
+			},
+			{ immediate: true },
+		);
+
+		const resetFilters = () => {
+			searchResultStore.setKeepFacets(false);
+			router.push({
+				name: 'Home',
+				query: { q: searchResultStore.currentQuery },
+			});
+		};
+
 		const setDelimitationFilterAndExecute = () => {
 			let val = '';
 			if ((tvToggled.value && radioToggled) || (!tvToggled.value && !radioToggled.value)) {
 				val = delimitationOptions.all;
+				searchResultStore.preliminaryFilter = '';
 			}
 			if (tvToggled.value && !radioToggled.value) {
 				val = delimitationOptions.tv;
@@ -174,18 +214,30 @@ export default defineComponent({
 			if (!tvToggled.value && radioToggled.value) {
 				val = delimitationOptions.radio;
 			}
-			searchResultStore.preliminaryFilter = val;
 			searchResultStore.resetAutocomplete();
-			const query = { ...route.query };
-			console.log(route.query);
-			let filters = [] as string[];
-			query.fq !== undefined ? (filters = [...(query.fq as string[])]) : null;
-			filters = filters.filter((str) => !str.includes('origin'));
-			query.fq = filters;
-
+			const routeQueries = cloneRouteQuery(route);
+			const existingFq = normalizeFq(routeQueries.fq as string[] | string);
+			if (existingFq) {
+				const creatorAffiliationFilter = existingFq.find((fq: string) => fq.includes('origin'));
+				if (creatorAffiliationFilter) {
+					const index = existingFq.findIndex((fq: string) => fq === creatorAffiliationFilter);
+					if (index !== -1) {
+						existingFq.splice(index, 1);
+					}
+				}
+				if (val !== '') {
+					existingFq.push(encodeURIComponent(val));
+				}
+				routeQueries.fq = existingFq;
+			} else {
+				if (val !== '') {
+					routeQueries.fq = [];
+					routeQueries.fq.push(encodeURIComponent(val));
+				}
+			}
 			router.push({
 				name: 'Home',
-				query: query,
+				query: routeQueries,
 			});
 		};
 
@@ -255,6 +307,7 @@ export default defineComponent({
 			radioToggled,
 			toggleRadio,
 			toggleTV,
+			resetFilters,
 		};
 	},
 });
@@ -307,8 +360,10 @@ export default defineComponent({
 }
 
 .sort-options {
+	position: relative;
 	display: flex;
 	justify-content: space-between;
+	z-index: 5;
 }
 
 .filter-options {
@@ -324,6 +379,7 @@ export default defineComponent({
 	color: #757575 !important;
 	background-color: rgb(250, 250, 250);
 	transition: all 0.2s linear 0s;
+	border: 1px solid #7575755e;
 }
 
 .filter-options.disabled button .dark-bar {
@@ -357,7 +413,6 @@ export default defineComponent({
 	background-color: transparent;
 	line-height: 24px;
 	cursor: pointer;
-	padding: 10px 10px;
 	margin: 10px 0px;
 	margin-right: auto;
 	margin-left: 0;
@@ -368,6 +423,8 @@ export default defineComponent({
 		1px 1px 2px #00000029;
 	border-radius: 4px;
 	z-index: 1;
+	font-size: 20px;
+	margin-right: 10px;
 }
 
 .filter-button .material-icons {
@@ -384,7 +441,7 @@ export default defineComponent({
 .source-facet-button {
 	cursor: pointer;
 	padding: 3px 3px;
-	font-size: 20px;
+	font-size: 18px;
 	width: fit-content;
 	display: flex;
 	align-items: center;
@@ -481,5 +538,39 @@ export default defineComponent({
 	left: 1px;
 	position: relative;
 	border-radius: 15px;
+}
+
+.reset {
+	cursor: pointer;
+	padding: 3px 3px;
+	font-size: 18px;
+	width: fit-content;
+	display: flex;
+	align-items: center;
+	border: 1px solid #f7ae3b;
+	background: #ffffff;
+	color: #002e70;
+	border-radius: 4px;
+	transition: all 0s linear 0s;
+	background-color: #f7ae3b;
+	max-height: 28px;
+	z-index: 1;
+	box-shadow:
+		inset 1px 1px 2px #00000000,
+		1px 1px 2px #00000029;
+}
+
+.reset span {
+	font-size: 25px;
+	padding-right: 5px;
+}
+
+.filter-buttons {
+	margin-right: auto;
+	display: flex;
+	align-items: center;
+	align-content: center;
+	flex-wrap: nowrap;
+	flex-direction: row;
 }
 </style>

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -42,6 +42,9 @@
       "dayHeadline":"Udvælg udedage",
       "timeslotHeadline":"Udvælg tidspunkter",
       "yearHeadline":"Vælg dato via kalender",
+      "filterOpenButton":"Tidspunkter",
+      "filterCloseButton":"Luk tidspunkter",
+      "filterApplyButton":"Anvend tidspunkter",
       "months": {
          "january": "januar",
          "february": "februar",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -42,6 +42,9 @@
       "dayHeadline":"Choose weekdays",
       "timeslotHeadline":"Choose timeslots",
       "yearHeadline":"Choose dates via calendar",
+      "filterOpenButton":"Moments",
+      "filterCloseButton":"Close moments",
+      "filterApplyButton":"Apply moments",
       "months": {
          "january": "January",
          "february": "February",

--- a/src/store/searchResultStore.ts
+++ b/src/store/searchResultStore.ts
@@ -68,16 +68,6 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 		filters.value.splice(filters.value.indexOf(filter), 1);
 	};
 
-	const addChannelFilter = (filter: string) => {
-		if (!channelFilters.value.includes(filter)) {
-			channelFilters.value.push(filter);
-		}
-	};
-
-	const removeChannelFilter = (filter: string) => {
-		channelFilters.value.splice(channelFilters.value.indexOf(filter), 1);
-	};
-
 	const setFiltersFromURL = (URLFilters: string[] | LocationQueryValue[] | string) => {
 		filters.value = [];
 		channelFilters.value = [];
@@ -204,9 +194,11 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 		lastSearchQuery.value = query;
 		resetAutocomplete();
 		let searchFilters = '';
+		let facetFilters = '';
 		if (filters.value.length > 0) {
 			filters.value.forEach((filt: string) => {
 				searchFilters += `&${filt}`;
+				facetFilters += `&${filt}`;
 			});
 		}
 		let channelFilterString = '';
@@ -214,6 +206,10 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 			channelFilterString = `&fq=(${channelFilters.value.join(' OR ')})`;
 		}
 		searchFilters += channelFilterString;
+		if (preliminaryFilter.value) {
+			searchFilters += `&fq=${preliminaryFilter.value}`;
+			facetFilters += `&fq=${preliminaryFilter.value}`;
+		}
 		const startParam = start.value === '' ? '' : `&start=${start.value}`;
 		const sortParam = sort.value === '' ? '' : `&sort=${sort.value}`;
 
@@ -238,7 +234,7 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 			);
 			const facetData = await APIService.getFacetResults(
 				query,
-				searchFilters,
+				facetFilters,
 				startParam as string,
 				sortParam as string,
 			);
@@ -289,6 +285,8 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 		resultGrid,
 		rowCount,
 		rowOffset,
+		channelFilters,
+		keepFacets,
 		addFilter,
 		resetFilters,
 		removeFilter,
@@ -311,7 +309,5 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 		setStart,
 		setRowCountFromURL,
 		setKeepFacets,
-		addChannelFilter,
-		removeChannelFilter,
 	};
 });

--- a/src/store/searchResultStore.ts
+++ b/src/store/searchResultStore.ts
@@ -31,10 +31,12 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 	const lastSearchQuery = ref('');
 	const noHits = ref(false);
 	const filters = ref([] as Array<string>);
+	const channelFilters = ref([] as Array<string>);
 	const preliminaryFilter = ref('');
 	const showFacets = ref(false);
 	const blockAutocomplete = ref(false);
 	const resultGrid = ref(false);
+	const keepFacets = ref(false);
 
 	const setStart = (value: string) => {
 		start.value = value;
@@ -62,13 +64,31 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 		}
 	};
 
+	const removeFilter = (filter: string) => {
+		filters.value.splice(filters.value.indexOf(filter), 1);
+	};
+
+	const addChannelFilter = (filter: string) => {
+		if (!channelFilters.value.includes(filter)) {
+			channelFilters.value.push(filter);
+		}
+	};
+
+	const removeChannelFilter = (filter: string) => {
+		channelFilters.value.splice(channelFilters.value.indexOf(filter), 1);
+	};
+
 	const setFiltersFromURL = (URLFilters: string[] | LocationQueryValue[] | string) => {
 		filters.value = [];
+		channelFilters.value = [];
 		if (URLFilters !== undefined) {
 			if (URLFilters instanceof Array) {
 				URLFilters.forEach((filter) => {
 					if (filter?.split(':')[0].includes('origin')) {
 						preliminaryFilter.value = filter;
+					} else if (filter?.includes('creator_affiliation_facet')) {
+						const cleanedString = filter.replace(/[()]/g, '');
+						channelFilters.value = cleanedString.split(' OR ');
 					} else {
 						filter !== '' ? filters.value.push(`fq=${filter}`) : null;
 					}
@@ -139,6 +159,7 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 		resetSort();
 		resetSpellCheck();
 		resetPreliminaryFilters();
+		setKeepFacets(false);
 		currentQuery.value = '';
 		searchFired.value = false;
 		loading.value = false;
@@ -157,12 +178,12 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 		autocompleteResult.value = [];
 	};
 
-	const removeFilter = (filter: string) => {
-		filters.value.splice(filters.value.indexOf(filter), 1);
-	};
-
 	const setBlockAutocomplete = (state: boolean) => {
 		blockAutocomplete.value = state;
+	};
+
+	const setKeepFacets = (state: boolean) => {
+		keepFacets.value = state;
 	};
 
 	const getAutocompleteResults = (query: string) => {
@@ -188,6 +209,11 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 				searchFilters += `&${filt}`;
 			});
 		}
+		let channelFilterString = '';
+		if (channelFilters.value.length > 0) {
+			channelFilterString = `&fq=(${channelFilters.value.join(' OR ')})`;
+		}
+		searchFilters += channelFilterString;
 		const startParam = start.value === '' ? '' : `&start=${start.value}`;
 		const sortParam = sort.value === '' ? '' : `&sort=${sort.value}`;
 
@@ -223,7 +249,9 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 				currentQuery.value = query;
 				searchResult.value = responseData.data.response.docs;
 				spellCheck.value = responseData.data.spellcheck;
-				facetResult.value = facetData.data.facet_counts.facet_fields as FacetResultType;
+				if (!keepFacets.value) {
+					facetResult.value = facetData.data.facet_counts.facet_fields as FacetResultType;
+				}
 				numFound.value = responseData.data.response.numFound;
 				noHits.value = numFound.value === 0;
 			}
@@ -282,5 +310,8 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 		setRowOffset,
 		setStart,
 		setRowCountFromURL,
+		setKeepFacets,
+		addChannelFilter,
+		removeChannelFilter,
 	};
 });

--- a/src/store/timeSearchStore.ts
+++ b/src/store/timeSearchStore.ts
@@ -13,9 +13,6 @@ export const useTimeSearchStore = defineStore('timeSearchStore', () => {
 	let comparisonSearchUUID = '';
 	const searchFired = ref(false);
 	const numFound = ref(0);
-	/* these are just the preset values. Should be updated when we got the new repo */
-	const startYear = ref(1921);
-	const endYear = ref(2022);
 	const noHits = ref(false);
 	const errorManager = inject('errorManager') as ErrorManagerType;
 	const error = ref('');
@@ -28,16 +25,8 @@ export const useTimeSearchStore = defineStore('timeSearchStore', () => {
 		return dateA > dateB ? 1 : -1;
 	};
 
-	const setStartYear = (val: number) => {
-		startYear.value = val;
-	};
-
 	const setNewSearchReqMet = (val: boolean) => {
 		newSearchReqMet.value = val;
-	};
-
-	const setEndYear = (val: number) => {
-		endYear.value = val;
 	};
 
 	const setLoading = (value: boolean) => {
@@ -114,13 +103,9 @@ export const useTimeSearchStore = defineStore('timeSearchStore', () => {
 	return {
 		loading,
 		timeResults,
-		startYear,
-		endYear,
 		setLoading,
 		getTimeSearchResults,
 		numFound,
-		setStartYear,
-		setEndYear,
 		newSearchReqMet,
 		setNewSearchReqMet,
 	};

--- a/src/store/timeSearchStore.ts
+++ b/src/store/timeSearchStore.ts
@@ -13,15 +13,31 @@ export const useTimeSearchStore = defineStore('timeSearchStore', () => {
 	let comparisonSearchUUID = '';
 	const searchFired = ref(false);
 	const numFound = ref(0);
+	/* these are just the preset values. Should be updated when we got the new repo */
+	const startYear = ref(1921);
+	const endYear = ref(2022);
 	const noHits = ref(false);
 	const errorManager = inject('errorManager') as ErrorManagerType;
 	const error = ref('');
 	const { t } = useI18n();
+	const newSearchReqMet = ref(false);
 
 	const sortFunction = (a: GenericSearchResultType, b: GenericSearchResultType) => {
 		const dateA = new Date(a.startTime).getTime();
 		const dateB = new Date(b.startTime).getTime();
 		return dateA > dateB ? 1 : -1;
+	};
+
+	const setStartYear = (val: number) => {
+		startYear.value = val;
+	};
+
+	const setNewSearchReqMet = (val: boolean) => {
+		newSearchReqMet.value = val;
+	};
+
+	const setEndYear = (val: number) => {
+		endYear.value = val;
 	};
 
 	const setLoading = (value: boolean) => {
@@ -98,8 +114,14 @@ export const useTimeSearchStore = defineStore('timeSearchStore', () => {
 	return {
 		loading,
 		timeResults,
+		startYear,
+		endYear,
 		setLoading,
 		getTimeSearchResults,
 		numFound,
+		setStartYear,
+		setEndYear,
+		newSearchReqMet,
+		setNewSearchReqMet,
 	};
 });

--- a/src/types/TimeSearchTypes.ts
+++ b/src/types/TimeSearchTypes.ts
@@ -31,4 +31,5 @@ export interface SelectorData {
 	name: string;
 	value: string;
 	selected: boolean;
+	index: number;
 }

--- a/src/utils/filter-utils.ts
+++ b/src/utils/filter-utils.ts
@@ -1,7 +1,5 @@
 import { RouteLocationNormalizedLoaded } from 'vue-router';
-import { useSearchResultStore } from '@/store/searchResultStore';
 import { FacetPair } from '@/types/GenericRecordTypes';
-
 const createTagFilter = (key: string) => {
 	return `${'categories:"' + key + '"'}`;
 };
@@ -10,11 +8,19 @@ const createAffiliationFilter = (key: string) => {
 	return `${'creator_affiliation_facet:"' + key + '"'}`;
 };
 
-const filterExists = (key: string, title: string) => {
+const filterExists = (key: string, title: string, parent: string[]) => {
 	if (title && key) {
-		const searchResultStore = useSearchResultStore();
 		const filterString = `${key}:"${title}"`;
-		return searchResultStore.filters.includes(`fq=${encodeURIComponent(filterString)}`);
+		return parent.includes(`fq=${encodeURIComponent(filterString)}`);
+	} else {
+		return false;
+	}
+};
+
+const channelFilterExists = (key: string, title: string, parent: string[]) => {
+	if (title && key) {
+		const filterString = `${key}:"${title}"`;
+		return parent.includes(encodeURIComponent(`${filterString}`));
 	} else {
 		return false;
 	}
@@ -31,7 +37,6 @@ const cloneRouteQuery = (route: RouteLocationNormalizedLoaded) => {
 };
 
 const addFilter = (route: RouteLocationNormalizedLoaded, filter: string) => {
-	console.log('wat?');
 	const routeQueries = cloneRouteQuery(route);
 	const newFilter = encodeURIComponent(filter);
 
@@ -58,6 +63,80 @@ const removeFilter = (route: RouteLocationNormalizedLoaded, filter: string) => {
 	return routeQueries;
 };
 
+function addChannelFilter(route: RouteLocationNormalizedLoaded, newFilter: string, keepTimeFacets: boolean) {
+	const routeQueries = cloneRouteQuery(route);
+	let existingFq = normalizeFq(routeQueries.fq as string[] | string);
+	if (keepTimeFacets === false) {
+		existingFq = removeTimeFacetsFromRoute(existingFq);
+	}
+	if (Array.isArray(existingFq)) {
+		const creatorAffiliationFilter = existingFq.find((fq: string) => fq.includes('creator_affiliation_facet'));
+		if (creatorAffiliationFilter) {
+			const index = existingFq.findIndex((fq: string) => fq === creatorAffiliationFilter);
+			if (index !== -1) {
+				existingFq.splice(index, 1);
+			}
+			const filters = creatorAffiliationFilter.replace(/[()]/g, '').split(' OR ');
+			filters.push(encodeURIComponent(`${newFilter}`));
+			const finalFilter = `(${filters.join(' OR ')})`;
+			existingFq.push(finalFilter);
+		} else {
+			existingFq.push(encodeURIComponent(`${newFilter}`));
+		}
+		routeQueries.fq = existingFq;
+	} else {
+		routeQueries.fq = [];
+		routeQueries.fq.push(encodeURIComponent(`${newFilter}`));
+	}
+	return routeQueries;
+}
+
+function removeChannelFilter(route: RouteLocationNormalizedLoaded, filterToRemove: string, keepTimeFacets: boolean) {
+	const routeQueries = cloneRouteQuery(route);
+	let existingFq = normalizeFq(routeQueries.fq as string[] | string);
+	if (keepTimeFacets === false) {
+		existingFq = removeTimeFacetsFromRoute(existingFq);
+	}
+	if (Array.isArray(existingFq)) {
+		const creatorAffiliationFilter = existingFq.find((fq: string) => fq.includes('creator_affiliation_facet'));
+		if (creatorAffiliationFilter) {
+			const index = existingFq.findIndex((fq: string) => fq === creatorAffiliationFilter);
+			if (index !== -1) {
+				existingFq.splice(index, 1);
+			}
+			let filters = creatorAffiliationFilter.replace(/[()]/g, '').split(' OR ');
+			filters = filters.filter((filter) => filter !== encodeURIComponent(filterToRemove));
+			const finalFilter = `(${filters.join(' OR ')})`;
+			if (filters.length !== 0) {
+				existingFq.push(finalFilter);
+			}
+		}
+		routeQueries.fq = existingFq;
+	}
+	return routeQueries;
+}
+
+const removeStringFromArray = (array: string[], str: string) => {
+	return array.filter((item) => !item.includes(str));
+};
+
+const removeTimeFacetsFromRoute = (fq: string[]) => {
+	let filter = [] as string[];
+	if (Array.isArray(fq)) {
+		filter = [...fq];
+		filter = removeStringFromArray(filter, 'startTime');
+		filter = removeStringFromArray(filter, 'temporal_start_day_da');
+		filter = removeStringFromArray(filter, 'temporal_start_month');
+		filter = removeStringFromArray(filter, 'temporal_start_hour_da');
+	}
+	return filter;
+};
+
+const normalizeFq = (fq: string | string[] | undefined): string[] => {
+	if (!fq) return [];
+	return Array.isArray(fq) ? fq : [fq];
+};
+
 // A simple method to arrange the facets in an orderly fasion, so they're easier to loop through.
 // Might not be relevant when we know more about the backend structure.
 const simplifyFacets = (facet: Array<string>): FacetPair[] => {
@@ -80,4 +159,17 @@ const simplifyFacets = (facet: Array<string>): FacetPair[] => {
 	return allPairedFacets;
 };
 
-export { createTagFilter, createAffiliationFilter, filterExists, addFilter, removeFilter, simplifyFacets };
+export {
+	createTagFilter,
+	createAffiliationFilter,
+	filterExists,
+	channelFilterExists,
+	addFilter,
+	removeFilter,
+	simplifyFacets,
+	addChannelFilter,
+	removeChannelFilter,
+	cloneRouteQuery,
+	normalizeFq,
+	removeTimeFacetsFromRoute,
+};

--- a/src/utils/filter-utils.ts
+++ b/src/utils/filter-utils.ts
@@ -31,6 +31,7 @@ const cloneRouteQuery = (route: RouteLocationNormalizedLoaded) => {
 };
 
 const addFilter = (route: RouteLocationNormalizedLoaded, filter: string) => {
+	console.log('wat?');
 	const routeQueries = cloneRouteQuery(route);
 	const newFilter = encodeURIComponent(filter);
 

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -162,6 +162,7 @@ export default defineComponent({
 					} else {
 						searchResultStore.setStartFromURL(route.query.start as string);
 					}
+					facetsChanged(newp, prevp) ? searchResultStore.setKeepFacets(true) : searchResultStore.setKeepFacets(false);
 					searchResultStore.setFiltersFromURL(route.query.fq as string[]);
 					searchResultStore.setSortFromURL(route.query.sort as string);
 					searchResultStore.setCurrentQueryFromURL(route.query.q as string);
@@ -182,6 +183,14 @@ export default defineComponent({
 
 		const checkIfSortIsChanged = (newSort: string, oldSort: string) => {
 			return newSort !== oldSort;
+		};
+
+		const facetsChanged = (newfq: RouteLocationNormalizedLoaded, oldfq: RouteLocationNormalizedLoaded) => {
+			if (JSON.stringify(newfq.query.fq) !== JSON.stringify(oldfq.query.fq)) {
+				return true;
+			} else {
+				return false;
+			}
 		};
 
 		const checkParamUpdate = (newParams: RouteLocationNormalizedLoaded, prevParams: RouteLocationNormalizedLoaded) => {


### PR DESCRIPTION
Okey, this is slightly bigger than it should have been - but Daniel kept coming back with more changes. Here's the overview:

Facets have now been completely rebuild - this PR and the one before took care of this. In this PR, the following is done:

- Channel facets now has a new layout, and has no limit. So we get all of them.
- Channel facets now only change on time and search term changes. This change was requested by UX. So you can now pick several channels on a single overall query, and see them displayed. We don't change them if the query is only updated by a channel facet. This meant a lot of work and a lot of checks for what is actually requested - and a lot of the PR is just that.
- All filters in a container now has the the selected displayed next to the headline - as buttons that can be removed again.
- This also means that the seprated facet request for the backend no longer has other applied channel facets send with it.
- Moved facets and search result headline around - requsted from UX.
- Added a reset filters - requested from UX (naming not done yet - UX is still figuring this stuff out)
- Added a "Luk tidspunkter" button at the bottom of the time search filters - requested by UX.
- Removed the months time selectors on the filter options. Requested by UX.

Overall, I think this works nicely. But a good rigorous testing would be lovely - there are now a lot of moving parts here now, when we change query to make sure we do things the right way.