### PR TITLE
DRA-1198 / DRA-1197: setup min max year & filter applied

### DIFF
--- a/src/components/common/TimeSearch/DatePicker.vue
+++ b/src/components/common/TimeSearch/DatePicker.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref, watch, onMounted } from 'vue';
+import { defineComponent, computed, ref, onMounted } from 'vue';
 import VueDatePicker from '@vuepic/vue-datepicker';
 import type { DatePickerInstance } from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
@@ -64,6 +64,15 @@ import { startDate, endDate, startYear, endYear } from '@/components/common/Time
 import { useTimeSearchStore } from '@/store/timeSearchStore';
 import { normalizeFq, cloneRouteQuery } from '@/utils/filter-utils';
 import { useRoute } from 'vue-router';
+
+interface Highlight {
+	dates: Date[];
+	years: number[];
+	months: { month: number; year: number }[];
+	quarters: { quarter: number; year: number }[];
+	weekdays: number[];
+	options: { highlightDisabled: boolean };
+}
 
 export default defineComponent({
 	name: 'DatePicker',
@@ -99,7 +108,6 @@ export default defineComponent({
 		});
 
 		const setDateFromISOString = (isoDate: string, date: Date) => {
-			console.log('setting date', isoDate);
 			const existingDate = new Date(isoDate);
 			date.setTime(existingDate.getTime());
 		};
@@ -120,14 +128,18 @@ export default defineComponent({
 			timeSearchStore.setNewSearchReqMet(true);
 		};
 
-		const highlightedDays = computed((): Date[] => {
+		const highlightedDays = computed(() => {
 			const timeDifference = endDate.value.getTime() - startDate.value.getTime();
 			const days = Math.ceil(timeDifference / (1000 * 60 * 60 * 24));
 			const highlights = [];
 			for (let i = 0; i < days; i++) {
 				highlights.push(addDays(startDate.value, i));
 			}
-			return highlights;
+
+			const highlight = {} as Highlight;
+			highlight.dates = highlights;
+
+			return highlight;
 		});
 
 		return {

--- a/src/components/common/TimeSearch/TimeSearchInitValues.ts
+++ b/src/components/common/TimeSearch/TimeSearchInitValues.ts
@@ -9,7 +9,7 @@ const timeSliderValues = ref<number[]>(initSliderValues.value);
 const startDate = ref<Date>(initStartDate.value); // January 1, 1992, 00:00:00
 const endDate = ref<Date>(initEndDate.value); // December 31, 1992, 23:59:59
 
-/* these are just the preset values. Should be updated when we got the new repo */
+/* these are just the preset values. Should be updated when we got the new index in solr */
 const startYear = ref<Date>(new Date(1921, 0, 1, 0, 0, 0));
 const endYear = ref<Date>(new Date(2022, 11, 31, 23, 59, 59));
 

--- a/src/components/common/TimelineHeadline.vue
+++ b/src/components/common/TimelineHeadline.vue
@@ -90,7 +90,6 @@ export default defineComponent({
 		const handleTimeFacetRemoval = (index: number, e: Event) => {
 			e.stopPropagation();
 			props.passUpdate(props.itemArray, index, false);
-			console.log('headline part', index);
 		};
 
 		const formatStringForTime = (val: string) => {

--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -146,23 +146,6 @@ export default defineComponent({
 			currentChannelNr.value = channelFacets.value.length ? channelFacets.value.length : 16;
 			categoryNr.value = categoryFacets.value.length ? Number(categoryFacets.value.length) : 0;
 
-			const routeQueries = cloneRouteQuery(route);
-			const fq = normalizeFq(routeQueries.fq);
-			const startTimeFilter = fq.find((fq: string) => fq.includes('startTime'));
-			if (startTimeFilter) {
-				const timestamps = decodeURIComponent(startTimeFilter)
-					.replace('startTime:', '')
-					.replace(' OR ', '')
-					.replace('[', '')
-					.replace(']', '')
-					.split(' TO ');
-				setDateFromISOString(timestamps[0], startDate.value);
-				setDateFromISOString(timestamps[1], endDate.value);
-			} else {
-				startDate.value.setTime(startYear.value.getTime());
-				endDate.value.setTime(endYear.value.getTime());
-			}
-
 			watch(
 				() => props.facetResults,
 				(newFacets: FacetResultType, prevFacets: FacetResultType) => {
@@ -187,11 +170,6 @@ export default defineComponent({
 				toggleFacets();
 			},
 		);
-
-		const setDateFromISOString = (isoDate: string, date: Date) => {
-			const existingDate = new Date(isoDate);
-			date.setTime(existingDate.getTime());
-		};
 
 		const newSearch = (yearSearch: boolean) => {
 			const routeQueries = cloneRouteQuery(route);

--- a/src/store/timeSearchStore.ts
+++ b/src/store/timeSearchStore.ts
@@ -18,11 +18,16 @@ export const useTimeSearchStore = defineStore('timeSearchStore', () => {
 	const error = ref('');
 	const { t } = useI18n();
 	const newSearchReqMet = ref(false);
+	const timeFacetsOpen = ref(false);
 
 	const sortFunction = (a: GenericSearchResultType, b: GenericSearchResultType) => {
 		const dateA = new Date(a.startTime).getTime();
 		const dateB = new Date(b.startTime).getTime();
 		return dateA > dateB ? 1 : -1;
+	};
+
+	const setTimeFacetsOpen = (val: boolean) => {
+		timeFacetsOpen.value = val;
 	};
 
 	const setNewSearchReqMet = (val: boolean) => {
@@ -108,5 +113,7 @@ export const useTimeSearchStore = defineStore('timeSearchStore', () => {
 		numFound,
 		newSearchReqMet,
 		setNewSearchReqMet,
+		timeFacetsOpen,
+		setTimeFacetsOpen,
 	};
 });


### PR DESCRIPTION
This PR fixes 2 things:

If no year restrictions are set when we search, the filters, when opened apply the start and end year numbers to the date pickers, so they're limited.

If you enter the site cold on a link with params set, the startTime values are not present in the filters. A new JIRA is made for the same to happen with all the other ones (month, day, timeslot, channel facets)