### PR TITLE
DRA-1245 - deselect bug in timesearch check all button

### DIFF
--- a/src/components/common/TimeSearch/TimeSearchFilters.vue
+++ b/src/components/common/TimeSearch/TimeSearchFilters.vue
@@ -481,12 +481,8 @@ export default defineComponent({
 					item.selected = true;
 				});
 			} else {
-				array.forEach((item, index) => {
-					if (index === 0) {
-						item.selected = true;
-					} else {
-						item.selected = false;
-					}
+				array.forEach((item) => {
+					item.selected = false;
 				});
 			}
 			if (!props.picker) {


### PR DESCRIPTION
Very simple. When you use a select all in either of the time search checkboxes (months, days, timeslots), when you press the all button, it should select all, or deselect all. Before, when you deselected, the first one would always be set to true aswell. Now they all deselect, as UX want it now (as reported in DRA-1245)