### PR TITLE
DRA-1250: Restyled resultpage to mimic the design from Daniel

### DIFF
--- a/src/components/global/nav/wc-header-menu.ts
+++ b/src/components/global/nav/wc-header-menu.ts
@@ -277,6 +277,7 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 		background-color:#caf0fe;
 		clip-path: polygon(0 0, 0 100%, 100% 0);
 		z-index: 3;
+		margin-top: -1px;
 	}
 	a {
 		font-weight: 700;

--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -16,7 +16,7 @@
 					>
 						<span class="material-icons first">today</span>
 						<span class="material-icons second">schedule</span>
-						{{ t('timeSearch.filterOpenButton') }}
+						<span class="toggle-time-text">{{ t('timeSearch.filterOpenButton') }}</span>
 						<span :class="timeSearchStore.timeFacetsOpen ? 'dark-bar open' : 'dark-bar closed'">
 							<span class="dot">
 								<TransitionGroup>
@@ -343,7 +343,7 @@ export default defineComponent({
 	cursor: pointer;
 	padding: 3px 3px;
 	font-size: 20px;
-	width: fit-content;
+	width: 100%;
 	display: flex;
 	align-items: center;
 	box-shadow: 1px 1px 2px #00000000;
@@ -353,6 +353,11 @@ export default defineComponent({
 	border-radius: 4px;
 	transition: all 0s linear 0s;
 	height: 36px;
+	background-color: #caf0fe;
+}
+
+.toggle-time-text {
+	margin-right: auto;
 }
 
 .time-facet-button.open {
@@ -501,6 +506,9 @@ h2 {
 	border-radius: 15px;
 }
 @media (min-width: 640px) {
+	.time-facet-button {
+		width: fit-content;
+	}
 	.checkbox {
 		flex: 0 0 50%;
 		max-width: 50%;

--- a/src/components/search/HitCount.vue
+++ b/src/components/search/HitCount.vue
@@ -65,7 +65,7 @@ export default defineComponent({
 	width: 100%;
 }
 .hit-count {
-	font-size: 36px;
+	font-size: 24px;
 }
 
 .loading-placeholder {
@@ -79,5 +79,10 @@ export default defineComponent({
 	border-radius: 15px;
 	background-color: rgba(170, 170, 170, 1);
 	height: 30px;
+}
+@media (min-width: 640px) {
+	.hit-count {
+		font-size: 36px;
+	}
 }
 </style>

--- a/src/components/search/ResultItem.vue
+++ b/src/components/search/ResultItem.vue
@@ -21,7 +21,7 @@
 						</router-link>
 						<div class="subtitle">
 							<span class="material-icons icons schedule">{{ resultdata.origin.split('.')[1] }}</span>
-							<span class="where">{{ resultdata.creator_affiliation[0] + ',' }}</span>
+							<span class="where">{{ resultdata.creator_affiliation + ',' }}</span>
 							<span class="when">{{ starttime }}</span>
 							<span class="material-icons icons schedule">schedule</span>
 							<span class="duration">{{ duration }}</span>
@@ -152,6 +152,8 @@ export default defineComponent({
 		const searchResultStore = useSearchResultStore();
 		const { t } = useI18n();
 
+		console.log(props.resultdata);
+
 		//Default imageData obj to prevent render issues
 		const imageData = ref(
 			JSON.stringify({
@@ -275,7 +277,7 @@ export default defineComponent({
 .container {
 	display: flex;
 	flex-direction: row;
-	height: 105px;
+	height: 175px;
 	justify-content: space-between;
 	gap: 30px;
 	width: 100%;
@@ -308,6 +310,7 @@ export default defineComponent({
 
 .result-image-wrapper {
 	width: 200px;
+	height: 105px;
 }
 
 .where,
@@ -462,9 +465,24 @@ export default defineComponent({
 	-webkit-box-orient: vertical;
 	line-height: 20px; /* fallback for firefox */
 	max-height: calc(20px * 3); /* fallback for firefox */
+	position: absolute;
+	top: 110px;
+}
+
+@media (min-width: 640px) {
 }
 
 @media (min-width: 800px) {
+	.container {
+		height: 105px;
+	}
+	.result-image-wrapper {
+		height: initial;
+	}
+	.summary {
+		position: initial;
+		top: 0px;
+	}
 	.title {
 		max-width: calc(100% - (200px - 60px));
 	}

--- a/src/components/search/SearchOverhead.vue
+++ b/src/components/search/SearchOverhead.vue
@@ -11,7 +11,7 @@
 							class="filter-button"
 							@click="toggleFacets()"
 						>
-							<span class="material-icons">tune</span>
+							<span class="material-icons">{{ !searchResultStore.showFacets ? 'tune' : 'close' }}</span>
 							<span class="filter-button-text">
 								{{ searchResultStore.showFacets ? $t('search.hideFilters') : $t('search.showFilters') }}
 							</span>
@@ -25,48 +25,50 @@
 							Reset filtre
 						</button>
 					</div>
-					<button
-						:class="tvToggled ? 'source-facet-button open' : 'source-facet-button'"
-						@click="toggleTV($event)"
-					>
-						<span class="material-icons second">play_circle_filled</span>
-						TV
-						<span :class="tvToggled ? 'dark-bar open' : 'dark-bar closed'">
-							<span class="dot">
-								<TransitionGroup>
-									<div
-										v-if="tvToggled"
-										class="close"
-									></div>
-									<div
-										v-else
-										class="check"
-									></div>
-								</TransitionGroup>
+					<div class="type-toggles">
+						<button
+							:class="tvToggled ? 'source-facet-button open' : 'source-facet-button'"
+							@click="toggleTV($event)"
+						>
+							<span class="material-icons second">play_circle_filled</span>
+							TV
+							<span :class="tvToggled ? 'dark-bar open' : 'dark-bar closed'">
+								<span class="dot">
+									<TransitionGroup>
+										<div
+											v-if="tvToggled"
+											class="close"
+										></div>
+										<div
+											v-else
+											class="check"
+										></div>
+									</TransitionGroup>
+								</span>
 							</span>
-						</span>
-					</button>
-					<button
-						:class="radioToggled ? 'source-facet-button open' : 'source-facet-button'"
-						@click="toggleRadio($event)"
-					>
-						<span class="material-icons second">volume_up</span>
-						RADIO
-						<span :class="radioToggled ? 'dark-bar open' : 'dark-bar closed'">
-							<span class="dot">
-								<TransitionGroup>
-									<div
-										v-if="radioToggled"
-										class="close"
-									></div>
-									<div
-										v-else
-										class="check"
-									></div>
-								</TransitionGroup>
+						</button>
+						<button
+							:class="radioToggled ? 'source-facet-button open' : 'source-facet-button'"
+							@click="toggleRadio($event)"
+						>
+							<span class="material-icons second">volume_up</span>
+							RADIO
+							<span :class="radioToggled ? 'dark-bar open' : 'dark-bar closed'">
+								<span class="dot">
+									<TransitionGroup>
+										<div
+											v-if="radioToggled"
+											class="close"
+										></div>
+										<div
+											v-else
+											class="check"
+										></div>
+									</TransitionGroup>
+								</span>
 							</span>
-						</span>
-					</button>
+						</button>
+					</div>
 				</div>
 				<Facets :facet-results="searchResultStore.facetResult" />
 				<div class="result-options">
@@ -314,7 +316,6 @@ export default defineComponent({
 
 <style scoped>
 .display-option {
-	color: #002e70;
 	background-color: transparent;
 	border: 0px;
 	cursor: pointer;
@@ -322,17 +323,26 @@ export default defineComponent({
 	width: 30px;
 	height: 30px;
 	border-bottom: 1px solid transparent;
+	color: grey;
 }
 
 .display-option.list {
 	position: relative;
 	margin-left: 30px;
 	margin-right: 5px;
+	padding-left: 2px;
 }
 
 .display-option.active {
 	border-bottom: 2px solid #002e70;
 	box-sizing: border-box;
+	color: #002e70;
+}
+
+.display-option.list,
+.display-option.grid {
+	top: 2px;
+	position: relative;
 }
 
 .display-option.loading {
@@ -341,13 +351,21 @@ export default defineComponent({
 }
 
 .display-option.list span {
-	font-size: 32px;
+	font-size: 35px;
 	position: relative;
-	top: -2px;
+	top: -5px;
+	left: -5px;
 }
 
 .container {
 	min-height: 91px;
+}
+
+.type-toggles {
+	display: flex;
+	gap: 10px;
+	width: 100%;
+	padding-bottom: 25px;
 }
 
 .result-options {
@@ -355,7 +373,10 @@ export default defineComponent({
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: flex-end;
-	height: 47px;
+	min-height: 47px;
+	z-index: 1;
+	position: relative;
+	padding-top: 25px;
 }
 
 .sort-options {
@@ -363,6 +384,7 @@ export default defineComponent({
 	display: flex;
 	justify-content: space-between;
 	z-index: 5;
+	flex-direction: column-reverse;
 }
 
 .filter-options {
@@ -370,6 +392,7 @@ export default defineComponent({
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: flex-end;
+	flex-direction: column-reverse;
 }
 
 .filter-options.disabled button {
@@ -399,7 +422,10 @@ export default defineComponent({
 .search-options {
 	display: flex;
 	flex-direction: row;
+	justify-content: flex-end;
 	align-items: center;
+	padding-top: 5px;
+	padding-bottom: 5px;
 }
 
 .page-count {
@@ -450,7 +476,6 @@ export default defineComponent({
 	color: #757575;
 	border-radius: 4px;
 	transition: all 0s linear 0s;
-	margin-left: 10px;
 	z-index: 1;
 }
 
@@ -571,5 +596,30 @@ export default defineComponent({
 	align-content: center;
 	flex-wrap: nowrap;
 	flex-direction: row;
+}
+
+@media (min-width: 640px) {
+	.filter-options {
+		flex-direction: row;
+	}
+	.type-toggles {
+		width: auto;
+		padding-bottom: 0px;
+	}
+
+	.source-facet-button {
+		width: auto;
+	}
+	.sort-options {
+		flex-direction: row;
+	}
+	.search-options {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+	}
+	.result-options {
+		padding-top: 0px;
+	}
 }
 </style>

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -198,11 +198,6 @@ export default defineComponent({
 }
 
 /* MEDIA QUERY 640 */
-@media (min-width: 800px) {
-	.hit-box:before {
-		display: block;
-	}
-}
 @media (min-width: 640px) {
 	.search-results.grid .hit-box {
 		width: calc(50% - 15px);
@@ -210,6 +205,14 @@ export default defineComponent({
 	}
 }
 
+/* MEDIA QUERY 800 */
+@media (min-width: 800px) {
+	.hit-box:before {
+		display: block;
+	}
+}
+
+/* MEDIA QUERY 990 */
 @media (min-width: 990px) {
 	.search-results.grid .hit-box {
 		width: calc(25% - 15px);

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -193,7 +193,7 @@ export default defineComponent({
 }
 
 .search-results.grid .hit-box {
-	width: calc(25% - 15px);
+	width: calc(100%);
 	box-sizing: border-box;
 }
 
@@ -201,6 +201,19 @@ export default defineComponent({
 @media (min-width: 800px) {
 	.hit-box:before {
 		display: block;
+	}
+}
+@media (min-width: 640px) {
+	.search-results.grid .hit-box {
+		width: calc(50% - 15px);
+		box-sizing: border-box;
+	}
+}
+
+@media (min-width: 990px) {
+	.search-results.grid .hit-box {
+		width: calc(25% - 15px);
+		box-sizing: border-box;
 	}
 }
 </style>

--- a/src/components/search/Sort.vue
+++ b/src/components/search/Sort.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="sort">
 		<span class="material-icons">sort</span>
-		<p ref="currentSort">{{ t('search.sortBy') }}:</p>
+		<p class="sort-by">{{ t('search.sortBy') }}:</p>
 		<button
 			ref="relevanceRef"
 			@click="newSort('score desc')"
@@ -102,6 +102,7 @@ export default defineComponent({
 	align-items: center;
 	padding-bottom: 20px;
 	padding-top: 20px;
+	justify-content: space-between;
 }
 
 .sort .active {
@@ -111,6 +112,10 @@ export default defineComponent({
 
 .sort .material-icons {
 	color: #002e70;
+}
+
+.sort-by {
+	margin-right: auto !important;
 }
 
 .sort p {
@@ -133,5 +138,13 @@ export default defineComponent({
 	top: 1px;
 	padding: 0px;
 	border-bottom: 2px solid transparent;
+}
+@media (min-width: 640px) {
+	.sort-by {
+		margin-right: initial;
+	}
+	.sort {
+		justify-content: initial;
+	}
 }
 </style>

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -268,6 +268,7 @@ h3 {
 	background-color: white;
 	clip-path: polygon(100% 0, 0 0, 0 100%);
 	z-index: 3;
+	top: -1px;
 }
 
 .edge.blue {


### PR DESCRIPTION
Give this a whirl, and have a look at the design on another screen (or tab between them, i know how you hate using your other screens ;-)). If you don't find any problems, we can push to develop and let Daniel have a test of it aswell. The XD file from Daniel can be found in the ticket DRA-1250, which is assigned to you aswell.

This includes
- Setup of all the overhead on the search result page
   - RADIO/TV toggles placement on mobile
   - Filter button placement on mobile
   - XXX found placement on mobile
   - page X of X placement on mobile
   - grid/list placement on mobile
   - sort placement on mobile
      
   - And last but not least, the search results themselves, they've been updated a little bit, both the layout and the skeleton.
   