### PR TITLE
DRA-809: Rework of header and searchfield and breadcrumb

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,21 +10,7 @@
 		</div>
 		<Notifier></Notifier>
 		<Spinner></Spinner>
-		<kb-menu
-			:routing="true"
-			:locale="currentLocale"
-			:page="$route.name"
-		></kb-menu>
-		<div
-			ref="wipe"
-			class="wipe"
-		>
-			<img
-				title="Royal Danish Library"
-				alt="Logo of the Royal Danish Library"
-				:src="getImgServerSrcURL()"
-			/>
-		</div>
+		<Header :locale="currentLocale"></Header>
 	</div>
 	<div class="content">
 		<router-view v-slot="{ Component }">
@@ -39,6 +25,16 @@
 			</transition>
 		</router-view>
 	</div>
+	<div
+		ref="wipe"
+		class="wipe"
+	>
+		<img
+			title="Royal Danish Library"
+			alt="Logo of the Royal Danish Library"
+			:src="getImgServerSrcURL()"
+		/>
+	</div>
 </template>
 
 <script lang="ts">
@@ -50,8 +46,7 @@ import Notifier from '@/components/global/notification/Notifier.vue';
 import Spinner from '@/components/global/spinner/Spinner.vue';
 import { LocalStorageWrapper } from './utils/local-storage-wrapper';
 import Footer from '@/components/global/nav/Footer.vue';
-
-import '@/components/global/nav/wc-header-menu';
+import Header from '@/components/search/Header.vue';
 
 export default defineComponent({
 	name: 'App',
@@ -59,6 +54,7 @@ export default defineComponent({
 		Notifier,
 		Spinner,
 		Footer,
+		Header,
 	},
 	setup() {
 		const td = ref(0.4);
@@ -145,10 +141,18 @@ export default defineComponent({
 		};
 
 		router.beforeEach((to, from) => {
-			if (from.name === 'Home' && to.name === 'Record') {
+			if (from.name === 'Search' && to.name === 'Record') {
 				transitionName.value = 'from-search-to-record';
+			} else if (from.name === 'Record' && to.name === 'Search') {
+				transitionName.value = 'from-record-to-search';
+			} else if (from.name === 'Home' && to.name === 'Search') {
+				transitionName.value = 'from-record-to-search';
+			} else if (from.name === 'Search' && to.name === 'Home') {
+				transitionName.value = 'from-record-to-search';
 			} else if (from.name === 'Record' && to.name === 'Home') {
 				transitionName.value = 'from-record-to-search';
+			} else if (from.name === 'Home' && to.name === 'Record') {
+				transitionName.value = 'from-search-to-record';
 			} else {
 				transitionName.value = 'swipe';
 			}
@@ -216,6 +220,10 @@ export default defineComponent({
 
 .result-enter {
 	transition-delay: 0.15s;
+}
+
+.app {
+	position: relative;
 }
 
 .result-enter-from,

--- a/src/components/global/nav/Breadcrumb.vue
+++ b/src/components/global/nav/Breadcrumb.vue
@@ -1,0 +1,162 @@
+<template>
+	<div class="bg-container">
+		<div class="breadcrumb container">
+			<span class="material-icons home">home</span>
+			<a href="https://www.kb.dk">
+				<span class="breadcrumb-title">{{ t('breadcrumb.frontpage') }}</span>
+			</a>
+			/
+			<a href="https://www.kb.dk/find-materiale">
+				<span class="breadcrumb-title">{{ t('breadcrumb.findMaterials') }}</span>
+			</a>
+			/
+			<router-link :to="{ name: 'Home' }">
+				<span class="breadcrumb-title highlighted">{{ t('breadcrumb.drArchive') }}</span>
+			</router-link>
+			<span v-if="$route.name === 'Search'">
+				<span>/</span>
+				<span class="breadcrumb-title">{{ t('breadcrumb.search') }}</span>
+			</span>
+			<router-link
+				v-if="$route.name === 'Record' && lastPath"
+				:to="lastPath"
+			>
+				<span>/</span>
+				<span class="breadcrumb-title">{{ t('breadcrumb.search') }}</span>
+			</router-link>
+			<router-link
+				v-if="$route.name === 'Record' && !lastPath"
+				:to="{ name: 'Search' }"
+			>
+				<span>/</span>
+				<span class="breadcrumb-title">{{ t('breadcrumb.search') }}</span>
+			</router-link>
+			<span v-if="$route.name === 'Record'">
+				<span>/</span>
+				<span class="breadcrumb-title">{{ t('breadcrumb.record') }}</span>
+			</span>
+		</div>
+	</div>
+</template>
+<script lang="ts">
+import { defineComponent, ref, onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { addTestDataEnrichment } from '@/utils/test-enrichments';
+import { useRouter } from 'vue-router';
+
+export default defineComponent({
+	name: 'Breadcrumb',
+	setup() {
+		const { t } = useI18n();
+		const router = useRouter();
+		const lastPath = ref('');
+
+		onMounted(() => {
+			lastPath.value = router.options.history.state.back as string;
+		});
+
+		return { t, addTestDataEnrichment, lastPath };
+	},
+});
+</script>
+
+<style scoped>
+.breadcrumb {
+	height: 40px;
+	position: relative;
+	background-color: #caf0fe;
+	z-index: 1;
+	display: flex;
+	flex-direction: row;
+	font-size: 16px;
+}
+
+.home {
+	font-size: 18px;
+}
+
+.breadcrumb a {
+	text-decoration: none;
+}
+
+.breadcrumb a:visited {
+	color: black;
+}
+
+.breadcrumb-title.highlighted {
+	color: white;
+	background-color: #002e70;
+	border-radius: 4px;
+}
+
+.bg-container {
+	z-index: 2;
+	background-color: #caf0fe;
+	position: relative;
+}
+
+.breadcrumb-title {
+	padding: 0px 0px;
+	text-decoration: none;
+	margin: 0px 2px;
+	color: black;
+	font-size: 12px;
+}
+
+.container {
+	text-align: left;
+	margin-right: auto;
+	margin-left: auto;
+	box-sizing: border-box;
+	padding-right: 12px;
+	padding-left: 12px;
+	align-items: center;
+}
+
+.container span {
+	color: black;
+}
+
+/* MEDIA QUERY 480 */
+@media (min-width: 480px) {
+	.container {
+		max-width: 640px;
+		padding-right: 12px;
+		padding-left: 12px;
+	}
+	.breadcrumb-title {
+		font-size: 14px;
+	}
+}
+/* MEDIA QUERY 640 */
+@media (min-width: 640px) {
+	.breadcrumb-title {
+		padding: 0px 3px;
+		margin: 0px 5px;
+		font-size: 16px;
+	}
+	.container {
+		max-width: 990px;
+	}
+}
+/* MEDIA QUERY 990 */
+@media (min-width: 990px) {
+	.container {
+		display: flex;
+		max-width: 1150px;
+	}
+}
+/* MEDIA QUERY 1150 */
+@media (min-width: 1150px) {
+	.container {
+		max-width: 1280px;
+	}
+}
+/* MEDIA QUERY 1280 */
+@media (min-width: 1280px) {
+	.container {
+		padding-right: 0;
+		padding-left: 0;
+	}
+}
+</style>

--- a/src/components/global/nav/Breadcrumb.vue
+++ b/src/components/global/nav/Breadcrumb.vue
@@ -42,10 +42,10 @@
 	</div>
 </template>
 <script lang="ts">
-import { defineComponent, ref, onMounted } from 'vue';
+import { defineComponent, ref, onMounted, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { addTestDataEnrichment } from '@/utils/test-enrichments';
-import { useRouter } from 'vue-router';
+import { useRouter, useRoute } from 'vue-router';
 import { useSearchResultStore } from '@/store/searchResultStore';
 
 export default defineComponent({
@@ -55,10 +55,18 @@ export default defineComponent({
 		const router = useRouter();
 		const lastPath = ref('');
 		const searchResultStore = useSearchResultStore();
+		const route = useRoute();
 
 		onMounted(() => {
 			lastPath.value = router.options.history.state.back as string;
 		});
+
+		watch(
+			() => route.path,
+			() => {
+				lastPath.value = router.options.history.state.back as string;
+			},
+		);
 
 		const emptyQuery = () => {
 			searchResultStore.currentQuery = '';

--- a/src/components/global/nav/Breadcrumb.vue
+++ b/src/components/global/nav/Breadcrumb.vue
@@ -10,7 +10,10 @@
 				<span class="breadcrumb-title">{{ t('breadcrumb.findMaterials') }}</span>
 			</a>
 			/
-			<router-link :to="{ name: 'Home' }">
+			<router-link
+				:to="{ name: 'Home' }"
+				@click="emptyQuery()"
+			>
 				<span class="breadcrumb-title highlighted">{{ t('breadcrumb.drArchive') }}</span>
 			</router-link>
 			<span v-if="$route.name === 'Search'">
@@ -43,6 +46,7 @@ import { defineComponent, ref, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { addTestDataEnrichment } from '@/utils/test-enrichments';
 import { useRouter } from 'vue-router';
+import { useSearchResultStore } from '@/store/searchResultStore';
 
 export default defineComponent({
 	name: 'Breadcrumb',
@@ -50,12 +54,20 @@ export default defineComponent({
 		const { t } = useI18n();
 		const router = useRouter();
 		const lastPath = ref('');
+		const searchResultStore = useSearchResultStore();
 
 		onMounted(() => {
 			lastPath.value = router.options.history.state.back as string;
 		});
 
-		return { t, addTestDataEnrichment, lastPath };
+		const emptyQuery = () => {
+			searchResultStore.currentQuery = '';
+			searchResultStore.loading = false;
+			searchResultStore.preliminaryFilter = '';
+			searchResultStore.resetSearch();
+		};
+
+		return { t, addTestDataEnrichment, lastPath, emptyQuery };
 	},
 });
 </script>

--- a/src/components/global/nav/Breadcrumb.vue
+++ b/src/components/global/nav/Breadcrumb.vue
@@ -19,7 +19,7 @@
 			<router-link
 				:to="{ name: 'Home' }"
 				:data-testid="addTestDataEnrichment('button', 'breadcrumb', 'frontpage', 2)"
-				@click="emptyQuery()"
+				@click="searchResultStore.resetSearch()"
 			>
 				<span class="breadcrumb-title highlighted">{{ t('breadcrumb.drArchive') }}</span>
 			</router-link>
@@ -77,14 +77,7 @@ export default defineComponent({
 			},
 		);
 
-		const emptyQuery = () => {
-			searchResultStore.currentQuery = '';
-			searchResultStore.loading = false;
-			searchResultStore.preliminaryFilter = '';
-			searchResultStore.resetSearch();
-		};
-
-		return { t, addTestDataEnrichment, lastPath, emptyQuery };
+		return { t, addTestDataEnrichment, lastPath, searchResultStore };
 	},
 });
 </script>

--- a/src/components/global/nav/Breadcrumb.vue
+++ b/src/components/global/nav/Breadcrumb.vue
@@ -1,49 +1,61 @@
 <template>
-	<div class="bg-container">
+	<div :class="`bg-container ${currentPage}`">
 		<div class="breadcrumb container">
-			<span class="material-icons home">home</span>
+			<span class="material-icons home-icon">home</span>
+			<span class="material-icons back-arrow">chevron_left</span>
 			<a
 				:data-testid="addTestDataEnrichment('button', 'breadcrumb', 'home-logo', 0)"
 				href="https://www.kb.dk"
+				class="level-1"
 			>
 				<span class="breadcrumb-title">{{ t('breadcrumb.frontpage') }}</span>
+				<span class="line">/</span>
 			</a>
-			/
 			<a
 				:data-testid="addTestDataEnrichment('button', 'breadcrumb', 'find-materials', 1)"
 				href="https://www.kb.dk/find-materiale"
+				class="level-2"
 			>
 				<span class="breadcrumb-title">{{ t('breadcrumb.findMaterials') }}</span>
+				<span class="line">/</span>
 			</a>
-			/
 			<router-link
 				:to="{ name: 'Home' }"
 				:data-testid="addTestDataEnrichment('button', 'breadcrumb', 'frontpage', 2)"
+				class="level-3"
 				@click="searchResultStore.resetSearch()"
 			>
 				<span class="breadcrumb-title highlighted">{{ t('breadcrumb.drArchive') }}</span>
 			</router-link>
-			<span v-if="$route.name === 'Search'">
-				<span>/</span>
+			<span
+				v-if="$route.name === 'Search'"
+				class="level-4"
+			>
+				<span class="line">/</span>
 				<span class="breadcrumb-title">{{ t('breadcrumb.search') }}</span>
 			</span>
 			<router-link
 				v-if="$route.name === 'Record' && lastPath"
+				class="level-5"
 				:data-testid="addTestDataEnrichment('button', 'breadcrumb', 'search-page-with-result', 3)"
 				:to="lastPath"
 			>
-				<span>/</span>
+				<span class="line">/</span>
 				<span class="breadcrumb-title">{{ t('breadcrumb.search') }}</span>
 			</router-link>
 			<router-link
 				v-if="$route.name === 'Record' && !lastPath"
+				class="level-5"
 				:to="{ name: 'Search' }"
 				:data-testid="addTestDataEnrichment('button', 'breadcrumb', 'search-page-empty', 4)"
 			>
-				<span>/</span>
+				<span class="line">/</span>
 				<span class="breadcrumb-title">{{ t('breadcrumb.search') }}</span>
 			</router-link>
-			<span v-if="$route.name === 'Record'">
+			<span
+				v-if="$route.name === 'Record'"
+				class="level-6"
+			>
 				<span>/</span>
 				<span class="breadcrumb-title">{{ t('breadcrumb.record') }}</span>
 			</span>
@@ -51,7 +63,7 @@
 	</div>
 </template>
 <script lang="ts">
-import { defineComponent, ref, onMounted, watch } from 'vue';
+import { defineComponent, ref, onMounted, watch, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { addTestDataEnrichment } from '@/utils/test-enrichments';
 import { useRouter, useRoute } from 'vue-router';
@@ -66,6 +78,15 @@ export default defineComponent({
 		const searchResultStore = useSearchResultStore();
 		const route = useRoute();
 
+		const currentPage = computed(() => {
+			let page = route.name as string;
+			if (page) {
+				return page.toLowerCase();
+			} else {
+				return '';
+			}
+		});
+
 		onMounted(() => {
 			lastPath.value = router.options.history.state.back as string;
 		});
@@ -77,7 +98,7 @@ export default defineComponent({
 			},
 		);
 
-		return { t, addTestDataEnrichment, lastPath, searchResultStore };
+		return { t, addTestDataEnrichment, lastPath, searchResultStore, currentPage };
 	},
 });
 </script>
@@ -93,7 +114,40 @@ export default defineComponent({
 	font-size: 16px;
 }
 
-.home {
+.level-1,
+.level-2,
+.level-3,
+.level-4,
+.level-5,
+.level-6 {
+	display: none;
+}
+
+.home .level-2,
+.home .level-3 {
+	display: initial;
+}
+
+.record .level-5,
+.record .level-6 {
+	display: initial;
+}
+
+.record .level-5 .line {
+	display: none;
+}
+
+.search .level-3,
+.search .level-4 {
+	display: initial;
+}
+
+.home-icon {
+	display: none;
+	font-size: 18px;
+}
+
+.back-arrow {
 	font-size: 18px;
 }
 
@@ -118,11 +172,15 @@ export default defineComponent({
 }
 
 .breadcrumb-title {
-	padding: 0px 0px;
+	padding: 0px 4px;
 	text-decoration: none;
 	margin: 0px 2px;
 	color: black;
 	font-size: 12px;
+}
+
+.record .breadcrumb-title.level-4 {
+	display: initial;
 }
 
 .container {
@@ -166,6 +224,27 @@ export default defineComponent({
 	.container {
 		display: flex;
 		max-width: 1150px;
+	}
+
+	.back-arrow {
+		display: none;
+	}
+
+	.level-1,
+	.level-2,
+	.level-3,
+	.level-4,
+	.level-5,
+	.level-6 {
+		display: initial;
+	}
+
+	.line {
+		display: initial !important;
+	}
+
+	.home-icon {
+		display: block;
 	}
 }
 /* MEDIA QUERY 1150 */

--- a/src/components/global/nav/Breadcrumb.vue
+++ b/src/components/global/nav/Breadcrumb.vue
@@ -155,6 +155,18 @@ export default defineComponent({
 	text-decoration: none;
 }
 
+.breadcrumb a:hover span {
+	color: #002e70;
+}
+
+.breadcrumb a:hover .line {
+	color: black;
+}
+
+.breadcrumb a:hover .highlighted {
+	color: white;
+}
+
 .breadcrumb a:visited {
 	color: black;
 }

--- a/src/components/global/nav/Breadcrumb.vue
+++ b/src/components/global/nav/Breadcrumb.vue
@@ -2,16 +2,23 @@
 	<div class="bg-container">
 		<div class="breadcrumb container">
 			<span class="material-icons home">home</span>
-			<a href="https://www.kb.dk">
+			<a
+				:data-testid="addTestDataEnrichment('button', 'breadcrumb', 'home-logo', 0)"
+				href="https://www.kb.dk"
+			>
 				<span class="breadcrumb-title">{{ t('breadcrumb.frontpage') }}</span>
 			</a>
 			/
-			<a href="https://www.kb.dk/find-materiale">
+			<a
+				:data-testid="addTestDataEnrichment('button', 'breadcrumb', 'find-materials', 1)"
+				href="https://www.kb.dk/find-materiale"
+			>
 				<span class="breadcrumb-title">{{ t('breadcrumb.findMaterials') }}</span>
 			</a>
 			/
 			<router-link
 				:to="{ name: 'Home' }"
+				:data-testid="addTestDataEnrichment('button', 'breadcrumb', 'frontpage', 2)"
 				@click="emptyQuery()"
 			>
 				<span class="breadcrumb-title highlighted">{{ t('breadcrumb.drArchive') }}</span>
@@ -22,6 +29,7 @@
 			</span>
 			<router-link
 				v-if="$route.name === 'Record' && lastPath"
+				:data-testid="addTestDataEnrichment('button', 'breadcrumb', 'search-page-with-result', 3)"
 				:to="lastPath"
 			>
 				<span>/</span>
@@ -30,6 +38,7 @@
 			<router-link
 				v-if="$route.name === 'Record' && !lastPath"
 				:to="{ name: 'Search' }"
+				:data-testid="addTestDataEnrichment('button', 'breadcrumb', 'search-page-empty', 4)"
 			>
 				<span>/</span>
 				<span class="breadcrumb-title">{{ t('breadcrumb.search') }}</span>

--- a/src/components/global/nav/wc-header-menu.ts
+++ b/src/components/global/nav/wc-header-menu.ts
@@ -7,6 +7,7 @@ class MenuComponent extends HTMLElement {
 	translation: MenuTranslation;
 	collapsed: boolean;
 	routing: boolean | undefined;
+	searchfieldopen: boolean;
 	constructor() {
 		super();
 		this.collapsed = true;
@@ -14,6 +15,7 @@ class MenuComponent extends HTMLElement {
 		this.lang = 'da';
 		this.shadow = this.attachShadow({ mode: 'open' });
 		this.shadow.innerHTML = MENU_COMPONENT_TEMPLATE + MENU_COMPONMENT_STYLES;
+		this.searchfieldopen = true;
 
 		const menuButton = this.shadow.querySelector('#mobileNavButton');
 		if (menuButton) {
@@ -21,27 +23,18 @@ class MenuComponent extends HTMLElement {
 		}
 
 		this.createFullHeaderMenu();
+		const searchMobileToggle: HTMLButtonElement | null | undefined = this.shadow.querySelector(
+			'#mobileMainSearchButton',
+		) as HTMLButtonElement;
+		searchMobileToggle
+			? searchMobileToggle.addEventListener('click', (e) => {
+					this.dispatchToggleSearchfield(e);
+			  })
+			: null;
 	}
 
 	static get observedAttributes() {
 		return ['locale', 'page'];
-	}
-
-	connectedCallback() {
-		const logo = this.shadow.querySelector('.rdl-logo');
-		if (logo && this.routing === true) {
-			logo.addEventListener('click', (event) => {
-				if (this.routing) {
-					event.preventDefault();
-					window.dispatchEvent(
-						new CustomEvent('change-path', {
-							detail: { name: 'Home', query: { q: '' } },
-						}),
-					);
-					window.dispatchEvent(new Event('reset-input'));
-				}
-			});
-		}
 	}
 
 	attributeChangedCallback(name: string, oldValue: string, newValue: string) {
@@ -62,6 +55,29 @@ class MenuComponent extends HTMLElement {
 	dispatchLocaleSwitch(e: Event) {
 		window.dispatchEvent(new Event('locale-switch'));
 		e.preventDefault();
+	}
+
+	dispatchToggleSearchfield(e: Event) {
+		window.dispatchEvent(new Event('toggle-search'));
+		e.preventDefault();
+		const searchToggle: HTMLSpanElement | null | undefined = this.shadow
+			.querySelector('#searchToggle')
+			?.querySelector('span');
+		const mobileSearchToggle: HTMLSpanElement | null | undefined = this.shadow
+			.querySelector('#mobileMainSearchButton')
+			?.querySelector('span');
+		this.searchfieldopen = !this.searchfieldopen;
+		if (this.searchfieldopen) {
+			searchToggle && (searchToggle.innerHTML = this.lang === 'da' ? 'Luk' : 'Close');
+			searchToggle && searchToggle.classList.add('cursive');
+			mobileSearchToggle && (mobileSearchToggle.innerHTML = this.lang === 'da' ? 'Luk' : 'Close');
+			mobileSearchToggle && mobileSearchToggle.classList.add('cursive');
+		} else {
+			searchToggle && (searchToggle.innerHTML = this.lang === 'da' ? 'Søg' : 'Search');
+			searchToggle && searchToggle.classList.remove('cursive');
+			mobileSearchToggle && (mobileSearchToggle.innerHTML = this.lang === 'da' ? 'Søg' : 'Search');
+			mobileSearchToggle && mobileSearchToggle.classList.remove('cursive');
+		}
 	}
 
 	toggleMenu() {
@@ -105,6 +121,27 @@ class MenuComponent extends HTMLElement {
 						this.dispatchLocaleSwitch(e);
 				  })
 				: null;
+			const searchToggle: HTMLSpanElement | null | undefined = this.shadow
+				.querySelector('#searchToggle')
+				?.querySelector('span');
+			searchToggle && searchToggle.classList.add('cursive');
+			searchToggle
+				? searchToggle.addEventListener('click', (e) => {
+						this.dispatchToggleSearchfield(e);
+				  })
+				: null;
+
+			const mobileSearchToggle: HTMLSpanElement | null | undefined = this.shadow
+				.querySelector('#mobileMainSearchButton')
+				?.querySelector('span');
+
+			if (this.searchfieldopen) {
+				mobileSearchToggle && (mobileSearchToggle.innerHTML = this.lang === 'da' ? 'Luk' : 'Close');
+				mobileSearchToggle && mobileSearchToggle.classList.add('cursive');
+			} else {
+				mobileSearchToggle && (mobileSearchToggle.innerHTML = this.lang === 'da' ? 'Søg' : 'Search');
+				mobileSearchToggle && mobileSearchToggle.classList.remove('cursive');
+			}
 		}
 	}
 
@@ -124,13 +161,21 @@ class MenuComponent extends HTMLElement {
 			listElem.classList.add(icon);
 		}
 		//listElem.role = 'none';
-		const link = document.createElement('a');
+		let link;
+		if (id) {
+			link = document.createElement('button');
+			link.id = id;
+			const titlespan = document.createElement('span');
+			titlespan.textContent = title;
+			link.appendChild(titlespan);
+		} else {
+			link = document.createElement('a');
+			link.href = url;
+			link.textContent = title;
+		}
 		listElem.role = 'menuitem';
-		if (id) link.id = id;
 		listElem.appendChild(link);
 		link.classList.add('nav-item', 'level-1');
-		link.textContent = title;
-		link.href = url;
 		link.setAttribute('data-testid', addTestDataEnrichment('link', 'topmenu', title, 0));
 		if (icon) {
 			const iconElem = document.createElement('i');
@@ -182,7 +227,7 @@ const menuTranslations = {
 			{ title: 'Arrangementer', link: 'https://www.kb.dk/arrangementer' },
 			{ title: 'Services', link: 'https://www.kb.dk/services' },
 			{ title: 'Besøg os', link: 'https://www.kb.dk/besoeg-os' },
-			{ title: 'Søg', link: 'https://www.kb.dk/', icon: 'search' },
+			{ title: 'Luk', link: '#', icon: 'search', id: 'searchToggle' },
 		],
 	},
 	en: {
@@ -205,7 +250,7 @@ const menuTranslations = {
 			{ title: 'Events', link: 'https://www.kb.dk/en/events' },
 			{ title: 'Services', link: 'https://www.kb.dk/en/services' },
 			{ title: 'Visit us', link: 'https://www.kb.dk/en/visit-us' },
-			{ title: 'Search', link: 'https://www.kb.dk/en', icon: 'search' },
+			{ title: 'Close', link: '#', icon: 'search', id: 'searchToggle' },
 		],
 	},
 };
@@ -221,14 +266,21 @@ const MENU_COMPONENT_TEMPLATE = /*html*/ `
 			<div class="logo-wrapper row justify-content-between">
 				<div class="col logo-col">
 					<a
-						href="/arkiv"
+						href="https://www.kb.dk"
 						class="rdl-logo"
 						title="Logo of the Royal Danish Library"
 						data-testid="link-topmenu-logo-0"
 					>
-						<span class="sr-only"></span>
+						<span class="sr-only">Royal Danish Library Logo</span>
 					</a>
 				</div>
+				<div class="col-auto d-lg-none search-col" role="search">
+						<button data-testid="button-topmenu-searchfield-toggle-0" id="mobileMainSearchButton" type="button" class="icon-button search-button d-lg-none" data-toggle="collapse" data-target="#mainSearch" aria-expanded="false" aria-controls="mainSearch" aria-label="">
+								<i class="material-icons " aria-hidden="true">search</i>
+
+							<span class="search-label cursive" aria-hidden="true">Luk</span>
+						</button>
+					</div>
 				<div class="col-auto d-lg-none burger-col">
 					<div id="mobileNavToggle">
 						<button data-testid="button-topmenu-menu-toggle-0" id="mobileNavButton" class="btn rdl-burger collapsed" data-toggle="collapse" data-target="#mobileNavigation" aria-expanded="false" aria-controls="mobileNavigation" aria-label="Åbn eller luk navigation" aria-pressed="false">
@@ -254,21 +306,27 @@ const MENU_COMPONENT_TEMPLATE = /*html*/ `
 		</div>
 	</div>
 </header>
-<div class="edge blue"></div>
 </div>
 
 `;
 
 const MENU_COMPONMENT_STYLES = /*css*/ `
 	<style>
-	.edge {
-		height:31px;
-	}
 
 	.overall-header {
 		position:relative;
 		z-index:2;
-		margin-bottom:50px;
+	}
+
+	.search-label {
+
+	}
+
+	.search-button {
+		display: flex;
+    flex-direction: column;
+    align-content: center;
+    align-items: center;
 	}
 
 	.rdl-logo {
@@ -280,15 +338,8 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 		display: inline-block;
 		height: 32px;
 		width: 138px;
-	}
-
-	.edge.blue {
-		width:100%;
-		position:absolute;
-		background-color:#caf0fe;
-		clip-path: polygon(0 0, 0 100%, 100% 0);
-		z-index: 3;
-		margin-top: -1px;
+		position:relative;
+		z-index:1;
 	}
 	a {
 		font-weight: 700;
@@ -296,6 +347,28 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 		text-decoration:none;
 		font-family: noway,sans-serif;
 		text-transform:uppercase;
+	}
+
+	.sr-only {
+		position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+	}
+
+	.rdl-secondary-nav button, .rdl-primary-nav button {
+		font-weight: 700;
+    color: #002e70;
+    text-decoration: none;
+    font-family: noway, sans-serif;
+    text-transform: uppercase;
+		font-size: 20px;
+		cursor:pointer;
 	}
 
 	.container {
@@ -310,16 +383,38 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 		box-sizing:border-box;
 	}
 
-	.global-header.open ~ .edge.blue {
-		display:none;
-	}
-
 	.global-header.open .header-bg-wrapper {
 		padding-bottom:0px;
 	}
 
 	.rdl-primary-nav li.search {
 		display:none;
+	}
+
+	.cursive {
+		font-style: italic;
+	}
+
+	.search-col button {
+		background-color: transparent;
+    border: 0px;
+		color: #002E70 !important;
+		margin-right: 15px;
+		cursor:pointer;
+	}
+
+	.search-col .material-icons {
+		font-size: 2.125rem;
+    margin-top: -2px;
+    margin-bottom: -1px;
+	}
+
+	.search-col span {
+		font-size:12px;
+		text-transform: uppercase;
+    font-family: "noway", sans-serif;
+		position: relative;
+    color: black;
 	}
 
 	.rdl-burger {
@@ -418,7 +513,7 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 
 	.global-header .header-bg-wrapper {
 		padding-top: 24px;
-		padding-bottom: 5px;
+		padding-bottom: 10px;
 	}
 	.global-header {
 		display: flex;
@@ -553,6 +648,7 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 		align-content: center;
 		flex-wrap: wrap;
 		align-content: flex-start;
+		flex-grow: 1;
 	}
 
 	.rdl-logo {
@@ -579,7 +675,11 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 	/* MEDIA QUERY 990 */
 	@media (min-width: 990px) {
 		.header-bg-wrapper.record {
-			margin-bottom:60px !important;
+			margin-bottom:0px !important;
+		}
+
+		.search-col {
+			display:none;
 		}
 
 		.rdl-primary-nav {
@@ -624,10 +724,6 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 			margin-top:initial;
 		}
 
-		.global-header.open ~ .edge.blue {
-			display: block;
-		}
-
 		.global-header .header-edge {
 			-webkit-clip-path: polygon(0 0, 100% 0, 100% calc(100% - 1.5vw), 0 100%);
 			clip-path: polygon(0 0, 100% 0, 100% calc(100% - 1.5vw), 0 100%);
@@ -641,6 +737,7 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 		}
 		.logo-col {
 			margin-left: -3px;
+			flex-grow: 1;
 		}
 		.logo-wrapper {
 			padding-left:0px;
@@ -732,9 +829,6 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 			width: 174px;
 		}
 
-		.edge.blue {
-			top:unset;
-		}
 		.overall-header {
 			margin-bottom:0px;
 		}
@@ -747,7 +841,7 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 	/* MEDIA QUERY 1150 */
 	@media (min-width: 1150px) {
 		.header-bg-wrapper.record {
-			margin-bottom:100px !important;
+			margin-bottom:0px !important;
 		}
 		.global-header .search i {
 			font-size: 1.25rem;

--- a/src/components/global/nav/wc-header-menu.ts
+++ b/src/components/global/nav/wc-header-menu.ts
@@ -630,7 +630,9 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 	}
 
 	.rdl-secondary-nav {
-		margin-top: 27px;	}
+		margin-top: 27px;
+		margin-bottom: 32px;
+	}
 
 	.rdl-secondary-nav:before {
 		content: '';
@@ -643,6 +645,19 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
     left: 0px;
     margin-top: -38px;
 	}
+
+	.rdl-secondary-nav:after {
+		content: '';
+    height: 25px;
+    width: 100vw;
+    position: absolute;
+    background-color: #96E2FD;
+    z-index: 3;
+    left: 0px;
+    margin-top: 12px;
+    clip-path: polygon(100% 0, 0 0, 0 100%);
+	}
+
 
 	.container {
 		display:flex;

--- a/src/components/global/nav/wc-header-menu.ts
+++ b/src/components/global/nav/wc-header-menu.ts
@@ -753,12 +753,13 @@ const MENU_COMPONMENT_STYLES = /*css*/ `
 			margin-left: 4px;
 		}
 
-		.rdl-secondary-nav:before {
+		.rdl-secondary-nav:before, .rdl-secondary-nav:after {
 			display:none;
 		}
 
 		.rdl-secondary-nav {
 			margin-top:initial;
+			margin-bottom:initial;
 		}
 
 		.global-header .header-edge {

--- a/src/components/global/nav/wc-header-menu.ts
+++ b/src/components/global/nav/wc-header-menu.ts
@@ -131,10 +131,13 @@ class MenuComponent extends HTMLElement {
 						this.dispatchLocaleSwitch(e);
 				  })
 				: null;
-			const searchToggle: HTMLSpanElement | null | undefined = this.shadow
+			const searchToggle: HTMLButtonElement | null | undefined = this.shadow.querySelector(
+				'#searchToggle',
+			) as HTMLButtonElement;
+			const searchToggleSpan: HTMLSpanElement | null | undefined = this.shadow
 				.querySelector('#searchToggle')
 				?.querySelector('span');
-			searchToggle && searchToggle.classList.add('cursive');
+			searchToggleSpan && searchToggleSpan.classList.add('cursive');
 			searchToggle
 				? searchToggle.addEventListener('click', (e) => {
 						this.dispatchToggleSearchfield(e);

--- a/src/components/global/nav/wc-header-menu.ts
+++ b/src/components/global/nav/wc-header-menu.ts
@@ -60,23 +60,33 @@ class MenuComponent extends HTMLElement {
 	dispatchToggleSearchfield(e: Event) {
 		window.dispatchEvent(new Event('toggle-search'));
 		e.preventDefault();
-		const searchToggle: HTMLSpanElement | null | undefined = this.shadow
+		const searchToggle: HTMLButtonElement | null | undefined = this.shadow.querySelector(
+			'#searchToggle',
+		) as HTMLButtonElement;
+		const mobileSearchToggle: HTMLButtonElement | null | undefined = this.shadow.querySelector(
+			'#mobileMainSearchButton',
+		) as HTMLButtonElement;
+		const searchToggleSpan: HTMLSpanElement | null | undefined = this.shadow
 			.querySelector('#searchToggle')
 			?.querySelector('span');
-		const mobileSearchToggle: HTMLSpanElement | null | undefined = this.shadow
+		const mobileSearchToggleSpan: HTMLSpanElement | null | undefined = this.shadow
 			.querySelector('#mobileMainSearchButton')
 			?.querySelector('span');
 		this.searchfieldopen = !this.searchfieldopen;
 		if (this.searchfieldopen) {
-			searchToggle && (searchToggle.innerHTML = this.lang === 'da' ? 'Luk' : 'Close');
-			searchToggle && searchToggle.classList.add('cursive');
-			mobileSearchToggle && (mobileSearchToggle.innerHTML = this.lang === 'da' ? 'Luk' : 'Close');
-			mobileSearchToggle && mobileSearchToggle.classList.add('cursive');
+			searchToggle.setAttribute('aria-expanded', 'true');
+			mobileSearchToggle.setAttribute('aria-expanded', 'true');
+			searchToggleSpan && (searchToggleSpan.innerHTML = this.lang === 'da' ? 'Luk' : 'Close');
+			searchToggleSpan && searchToggleSpan.classList.add('cursive');
+			mobileSearchToggleSpan && (mobileSearchToggleSpan.innerHTML = this.lang === 'da' ? 'Luk' : 'Close');
+			mobileSearchToggleSpan && mobileSearchToggleSpan.classList.add('cursive');
 		} else {
-			searchToggle && (searchToggle.innerHTML = this.lang === 'da' ? 'Søg' : 'Search');
-			searchToggle && searchToggle.classList.remove('cursive');
-			mobileSearchToggle && (mobileSearchToggle.innerHTML = this.lang === 'da' ? 'Søg' : 'Search');
-			mobileSearchToggle && mobileSearchToggle.classList.remove('cursive');
+			searchToggle.setAttribute('aria-expanded', 'false');
+			mobileSearchToggle.setAttribute('aria-expanded', 'false');
+			searchToggleSpan && (searchToggleSpan.innerHTML = this.lang === 'da' ? 'Søg' : 'Search');
+			searchToggleSpan && searchToggleSpan.classList.remove('cursive');
+			mobileSearchToggleSpan && (mobileSearchToggleSpan.innerHTML = this.lang === 'da' ? 'Søg' : 'Search');
+			mobileSearchToggleSpan && mobileSearchToggleSpan.classList.remove('cursive');
 		}
 	}
 
@@ -168,6 +178,9 @@ class MenuComponent extends HTMLElement {
 			const titlespan = document.createElement('span');
 			titlespan.textContent = title;
 			link.appendChild(titlespan);
+			if (id === 'searchToggle') {
+				link.setAttribute('aria-expanded', 'true');
+			}
 		} else {
 			link = document.createElement('a');
 			link.href = url;
@@ -275,7 +288,7 @@ const MENU_COMPONENT_TEMPLATE = /*html*/ `
 					</a>
 				</div>
 				<div class="col-auto d-lg-none search-col" role="search">
-						<button data-testid="button-topmenu-searchfield-toggle-0" id="mobileMainSearchButton" type="button" class="icon-button search-button d-lg-none" data-toggle="collapse" data-target="#mainSearch" aria-expanded="false" aria-controls="mainSearch" aria-label="">
+						<button data-testid="button-topmenu-searchfield-toggle-0" id="mobileMainSearchButton" type="button" class="icon-button search-button d-lg-none" data-toggle="collapse" data-target="#mainSearch" aria-expanded="true" aria-controls="mainSearch" aria-label="">
 								<i class="material-icons " aria-hidden="true">search</i>
 
 							<span class="search-label cursive" aria-hidden="true">Luk</span>

--- a/src/components/global/nav/wc-header-menu.ts
+++ b/src/components/global/nav/wc-header-menu.ts
@@ -78,6 +78,8 @@ class MenuComponent extends HTMLElement {
 			mobileSearchToggle.setAttribute('aria-expanded', 'true');
 			searchToggleSpan && (searchToggleSpan.innerHTML = this.lang === 'da' ? 'Luk' : 'Close');
 			searchToggleSpan && searchToggleSpan.classList.add('cursive');
+			searchToggle?.setAttribute('aria-label', this.lang === 'da' ? 'Luk søgefelt' : 'Close searchfield');
+			mobileSearchToggle?.setAttribute('aria-label', this.lang === 'da' ? 'Luk søgefelt' : 'Close searchfield');
 			mobileSearchToggleSpan && (mobileSearchToggleSpan.innerHTML = this.lang === 'da' ? 'Luk' : 'Close');
 			mobileSearchToggleSpan && mobileSearchToggleSpan.classList.add('cursive');
 		} else {
@@ -85,6 +87,8 @@ class MenuComponent extends HTMLElement {
 			mobileSearchToggle.setAttribute('aria-expanded', 'false');
 			searchToggleSpan && (searchToggleSpan.innerHTML = this.lang === 'da' ? 'Søg' : 'Search');
 			searchToggleSpan && searchToggleSpan.classList.remove('cursive');
+			searchToggle?.setAttribute('aria-label', this.lang === 'da' ? 'Åben søgefelt' : 'Open searchfield');
+			mobileSearchToggle?.setAttribute('aria-label', this.lang === 'da' ? 'Åben søgefelt' : 'Open searchfield');
 			mobileSearchToggleSpan && (mobileSearchToggleSpan.innerHTML = this.lang === 'da' ? 'Søg' : 'Search');
 			mobileSearchToggleSpan && mobileSearchToggleSpan.classList.remove('cursive');
 		}
@@ -154,6 +158,8 @@ class MenuComponent extends HTMLElement {
 			} else {
 				mobileSearchToggle && (mobileSearchToggle.innerHTML = this.lang === 'da' ? 'Søg' : 'Search');
 				mobileSearchToggle && mobileSearchToggle.classList.remove('cursive');
+				searchToggle?.setAttribute('aria-label', this.lang === 'da' ? 'Luk søgefelt' : 'Close searchfield');
+				mobileSearchToggle?.setAttribute('aria-label', this.lang === 'da' ? 'Luk søgefelt' : 'Close searchfield');
 			}
 		}
 	}
@@ -291,7 +297,7 @@ const MENU_COMPONENT_TEMPLATE = /*html*/ `
 					</a>
 				</div>
 				<div class="col-auto d-lg-none search-col" role="search">
-						<button data-testid="button-topmenu-searchfield-toggle-0" id="mobileMainSearchButton" type="button" class="icon-button search-button d-lg-none" data-toggle="collapse" data-target="#mainSearch" aria-expanded="true" aria-controls="mainSearch" aria-label="">
+						<button data-testid="button-topmenu-searchfield-toggle-0" id="mobileMainSearchButton" type="button" class="icon-button search-button d-lg-none" data-toggle="collapse" aria-expanded="true" aria-label="Luk søgefelt">
 								<i class="material-icons " aria-hidden="true">search</i>
 
 							<span class="search-label cursive" aria-hidden="true">Luk</span>

--- a/src/components/records/BroadcastVideoRecord.vue
+++ b/src/components/records/BroadcastVideoRecord.vue
@@ -65,7 +65,7 @@
 			</router-link>
 			<router-link
 				v-else
-				to="/"
+				:to="{ name: 'Home' }"
 				:data-testid="addTestDataEnrichment('link', 'broadcast-video', 'frontpage-link', 0)"
 			>
 				<span class="material-icons offset">chevron_left</span>

--- a/src/components/search/Header.vue
+++ b/src/components/search/Header.vue
@@ -1,0 +1,46 @@
+<template>
+	<div>
+		<kb-menu
+			:routing="true"
+			:locale="locale"
+			:page="$route.name"
+		></kb-menu>
+		<SearchBar />
+		<Breadcrumb />
+		<div class="edge top"></div>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import '@/components/global/nav/wc-header-menu';
+import SearchBar from '@/components/search/SearchBar.vue';
+import Breadcrumb from '@/components/global/nav/Breadcrumb.vue';
+export default defineComponent({
+	name: 'Header',
+	components: {
+		SearchBar,
+		Breadcrumb,
+	},
+	props: {
+		locale: { type: String, required: true },
+	},
+	setup() {
+		return {};
+	},
+});
+</script>
+<style scoped>
+.edge.top {
+	width: 110%;
+	position: relative;
+	background-color: #caf0fe;
+	z-index: 0;
+	height: 6vw;
+	left: -5%;
+	transform: rotateZ(-2deg);
+	transform-origin: center bottom;
+	top: calc(-4vw);
+	z-index: 1;
+}
+</style>

--- a/src/components/search/Hero.vue
+++ b/src/components/search/Hero.vue
@@ -1,0 +1,45 @@
+<template>
+	<div class="hero-container">
+		<img
+			:src="backgroundImage"
+			title="search background"
+			alt="Image of the Royal Danish Library"
+			loading="lazy"
+			class="bg-image"
+		/>
+	</div>
+</template>
+<script>
+import { defineComponent, computed } from 'vue';
+
+export default defineComponent({
+	name: 'Hero',
+
+	setup() {
+		const backgroundImage = computed(() => {
+			return new URL(`@/assets/images/_Den_Sorte_Diamant-Laura_Stamer-min.jpg`, import.meta.url).href;
+		});
+
+		return {
+			backgroundImage,
+		};
+	},
+});
+</script>
+<style scoped>
+.hero-container {
+	position: relative;
+	height: 400px;
+	display: flex;
+	justify-content: center;
+	margin-top: -85px;
+	margin-bottom: 85px;
+}
+
+.bg-image {
+	width: 100vw;
+	height: 100%;
+	object-fit: cover;
+	position: absolute;
+}
+</style>

--- a/src/components/search/Hero.vue
+++ b/src/components/search/Hero.vue
@@ -32,7 +32,7 @@ export default defineComponent({
 	height: 400px;
 	display: flex;
 	justify-content: center;
-	margin-top: -85px;
+	margin-top: -6vw;
 	margin-bottom: 85px;
 }
 

--- a/src/components/search/HitCount.vue
+++ b/src/components/search/HitCount.vue
@@ -66,6 +66,8 @@ export default defineComponent({
 }
 .hit-count {
 	font-size: 24px;
+	position: relative;
+	z-index: 0;
 }
 
 .loading-placeholder {

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -82,6 +82,7 @@
 										aria-expanded="false"
 										title="Select portal"
 										aria-controls="searchbar-select-portal"
+										:data-testid="addTestDataEnrichment('button', 'portal', 'select-portal-toggle', 0)"
 										@click="togglePortalSelector()"
 									>
 										<div class="filter-option">
@@ -115,6 +116,7 @@
 														type="button"
 														class="dropdown-item"
 														:title="t(`search.portals.${selectorValues[0].name}`)"
+														:data-testid="addTestDataEnrichment('button', 'portal', 'drarchive', 0)"
 														@click="selectPortal(0)"
 													>
 														<span class="text">
@@ -127,6 +129,7 @@
 														type="button"
 														class="dropdown-item"
 														:title="t(`search.portals.${selectorValues[1].name}`)"
+														:data-testid="addTestDataEnrichment('button', 'portal', 'primo', 0)"
 														@click="selectPortal(1)"
 													>
 														<span class="text">
@@ -139,6 +142,7 @@
 														type="button"
 														class="dropdown-item"
 														:title="t(`search.portals.${selectorValues[2].name}`)"
+														:data-testid="addTestDataEnrichment('button', 'portal', 'kbdk', 0)"
 														@click="selectPortal(2)"
 													>
 														<span class="text">
@@ -151,6 +155,7 @@
 														type="button"
 														class="dropdown-item"
 														:title="t(`search.portals.${selectorValues[3].name}`)"
+														:data-testid="addTestDataEnrichment('button', 'portal', 'webshop', 0)"
 														@click="selectPortal(3)"
 													>
 														<span class="text">
@@ -163,6 +168,7 @@
 														:title="t(`search.portals.${selectorValues[4].name}`)"
 														class="dropdown-item"
 														:href="'https://www.kb.dk/find-materiale'"
+														:data-testid="addTestDataEnrichment('link', 'portal', 'all-materials', 0)"
 													>
 														<span class="text">
 															{{ t(`search.portals.${selectorValues[4].name}`) }}
@@ -219,7 +225,7 @@ export default defineComponent({
 	},
 
 	setup() {
-		const { t, locale } = useI18n();
+		const { t } = useI18n();
 		const visibleSearchfield = ref(true);
 		const searchResultStore = useSearchResultStore();
 		const debounceMechanic = ref(false);
@@ -774,6 +780,10 @@ input:focus {
 	text-rendering: optimizeLegibility;
 	-moz-osx-font-smoothing: grayscale;
 	font-feature-settings: 'liga';
+}
+
+.dropdown-menu-inner li:last-child {
+	border-top: 1px solid #d6d6d6;
 }
 
 .filter-option {

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -78,17 +78,15 @@
 										class="btn dropdown-toggle btn-outline-primary"
 										data-toggle="dropdown"
 										role="combobox"
-										aria-owns="bs-select-1"
 										aria-haspopup="listbox"
 										aria-expanded="false"
-										title="DR Archive"
+										title="Select portal"
 										aria-controls="searchbar-select-portal"
 										@click="togglePortalSelector()"
 									>
 										<div class="filter-option">
 											<div class="filter-option-inner">
 												<div class="filter-option-inner-inner">
-													<span class="sr-only"></span>
 													{{ t(`search.portals.${selectedPortal}`) }}
 												</div>
 											</div>
@@ -102,91 +100,71 @@
 											id="bs-select-1"
 											class="inner show"
 											role="listbox"
-											tabindex="-1"
-											aria-activedescendant="bs-select-1-0"
+											tabindex="1"
 										>
 											<ul
 												class="dropdown-menu-inner inner show"
 												role="presentation"
 												style="margin-top: 0px; margin-bottom: 0px"
 											>
-												<li class="selected active">
+												<li
+													role="option"
+													class="selected active"
+												>
 													<button
-														id="bs-select-1-0"
 														type="button"
-														role="option"
-														class="dropdown-item active selected"
-														tabindex="0"
-														aria-setsize="4"
-														aria-posinset="1"
-														aria-selected="true"
+														class="dropdown-item"
+														:title="t(`search.portals.${selectorValues[0].name}`)"
 														@click="selectPortal(0)"
 													>
 														<span class="text">
-															<span class="sr-only"></span>
 															{{ t(`search.portals.${selectorValues[0].name}`) }}
 														</span>
 													</button>
 												</li>
-												<li>
+												<li role="option">
 													<button
-														id="bs-select-1-0"
 														type="button"
-														role="option"
-														class="dropdown-item active selected"
-														tabindex="0"
-														aria-setsize="4"
-														aria-posinset="1"
-														aria-selected="true"
+														class="dropdown-item"
+														:title="t(`search.portals.${selectorValues[1].name}`)"
 														@click="selectPortal(1)"
 													>
 														<span class="text">
-															<span class="sr-only"></span>
 															{{ t(`search.portals.${selectorValues[1].name}`) }}
 														</span>
 													</button>
 												</li>
-												<li>
+												<li role="option">
 													<button
-														id="bs-select-1-1"
 														type="button"
-														role="option"
 														class="dropdown-item"
-														tabindex="0"
+														:title="t(`search.portals.${selectorValues[2].name}`)"
 														@click="selectPortal(2)"
 													>
 														<span class="text">
-															<span class="sr-only"></span>
 															{{ t(`search.portals.${selectorValues[2].name}`) }}
 														</span>
 													</button>
 												</li>
-												<li>
+												<li role="option">
 													<button
-														id="bs-select-1-2"
 														type="button"
-														role="option"
 														class="dropdown-item"
-														tabindex="0"
+														:title="t(`search.portals.${selectorValues[3].name}`)"
 														@click="selectPortal(3)"
 													>
 														<span class="text">
-															<span class="sr-only"></span>
 															{{ t(`search.portals.${selectorValues[3].name}`) }}
 														</span>
 													</button>
 												</li>
-												<li>
+												<li role="option">
 													<a
-														id="bs-select-1-3"
-														type="button"
-														role="option"
+														:title="t(`search.portals.${selectorValues[4].name}`)"
 														class="dropdown-item"
-														tabindex="0"
 														:href="'https://www.kb.dk/find-materiale'"
 													>
 														<span class="text">
-															<span class="sr-only"></span>
 															{{ t(`search.portals.${selectorValues[4].name}`) }}
 														</span>
 													</a>

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -1,17 +1,12 @@
 <template>
 	<div class="search-box">
-		<img
-			:src="backgroundImage"
-			title="search background"
-			alt="Image of the Royal Danish Library"
-			loading="lazy"
-			class="bg-image"
-		/>
 		<div class="search-container">
 			<div class="container main-12">
 				<div class="row">
 					<div class="col">
 						<form
+							ref="searchFormRef"
+							class="searchform"
 							action=" "
 							method=" "
 							role="search"
@@ -36,7 +31,7 @@
 										type="search"
 										:disabled="debounceMechanic ? true : false"
 										class="form-control"
-										:placeholder="t('search.searchInput')"
+										:placeholder="t(`search.placeholders.${selectedPortal}`)"
 										name="simpleSearch"
 										:data-testid="addTestDataEnrichment('input', 'searchbar', 'search-field', 0)"
 										@keydown="updateKeystrokeForAutocomplete"
@@ -76,6 +71,130 @@
 										close
 									</i>
 								</button>
+								<div class="dropdown bootstrap-select">
+									<button
+										ref="selectButtonRef"
+										type="button"
+										class="btn dropdown-toggle btn-outline-primary"
+										data-toggle="dropdown"
+										role="combobox"
+										aria-owns="bs-select-1"
+										aria-haspopup="listbox"
+										aria-expanded="false"
+										title="DR Archive"
+										aria-controls="searchbar-select-portal"
+										@click="togglePortalSelector()"
+									>
+										<div class="filter-option">
+											<div class="filter-option-inner">
+												<div class="filter-option-inner-inner">
+													<span class="sr-only"></span>
+													{{ t(`search.portals.${selectedPortal}`) }}
+												</div>
+											</div>
+										</div>
+									</button>
+									<div
+										:class="showPortalSelector ? 'dropdown-menu select-show' : 'dropdown-menu'"
+										style=""
+									>
+										<div
+											id="bs-select-1"
+											class="inner show"
+											role="listbox"
+											tabindex="-1"
+											aria-activedescendant="bs-select-1-0"
+										>
+											<ul
+												class="dropdown-menu-inner inner show"
+												role="presentation"
+												style="margin-top: 0px; margin-bottom: 0px"
+											>
+												<li class="selected active">
+													<button
+														id="bs-select-1-0"
+														type="button"
+														role="option"
+														class="dropdown-item active selected"
+														tabindex="0"
+														aria-setsize="4"
+														aria-posinset="1"
+														aria-selected="true"
+														@click="selectPortal(0)"
+													>
+														<span class="text">
+															<span class="sr-only"></span>
+															{{ t(`search.portals.${selectorValues[0].name}`) }}
+														</span>
+													</button>
+												</li>
+												<li>
+													<button
+														id="bs-select-1-0"
+														type="button"
+														role="option"
+														class="dropdown-item active selected"
+														tabindex="0"
+														aria-setsize="4"
+														aria-posinset="1"
+														aria-selected="true"
+														@click="selectPortal(1)"
+													>
+														<span class="text">
+															<span class="sr-only"></span>
+															{{ t(`search.portals.${selectorValues[1].name}`) }}
+														</span>
+													</button>
+												</li>
+												<li>
+													<button
+														id="bs-select-1-1"
+														type="button"
+														role="option"
+														class="dropdown-item"
+														tabindex="0"
+														@click="selectPortal(2)"
+													>
+														<span class="text">
+															<span class="sr-only"></span>
+															{{ t(`search.portals.${selectorValues[2].name}`) }}
+														</span>
+													</button>
+												</li>
+												<li>
+													<button
+														id="bs-select-1-2"
+														type="button"
+														role="option"
+														class="dropdown-item"
+														tabindex="0"
+														@click="selectPortal(3)"
+													>
+														<span class="text">
+															<span class="sr-only"></span>
+															{{ t(`search.portals.${selectorValues[3].name}`) }}
+														</span>
+													</button>
+												</li>
+												<li>
+													<a
+														id="bs-select-1-3"
+														type="button"
+														role="option"
+														class="dropdown-item"
+														tabindex="0"
+														:href="'https://www.kb.dk/find-materiale'"
+													>
+														<span class="text">
+															<span class="sr-only"></span>
+															{{ t(`search.portals.${selectorValues[4].name}`) }}
+														</span>
+													</a>
+												</li>
+											</ul>
+										</div>
+									</div>
+								</div>
 								<button
 									id="searchButton"
 									ref="searchButton"
@@ -101,18 +220,19 @@
 				</div>
 			</div>
 		</div>
-		<div class="edge white"></div>
 	</div>
 </template>
 
 <script lang="ts">
-import { ref, computed, defineComponent, watch } from 'vue';
+import { ref, defineComponent, watch, onMounted, onUnmounted } from 'vue';
 import { useSearchResultStore } from '@/store/searchResultStore';
 import Autocomplete from '@/components/search/Autocomplete.vue';
 import { LocationQueryRaw } from 'vue-router';
 import router from '@/router';
 import { useI18n } from 'vue-i18n';
 import { addTestDataEnrichment } from '@/utils/test-enrichments';
+import gsap from 'gsap';
+import { PortalSelectItem } from '@/types/SearchBarTypes';
 
 export default defineComponent({
 	name: 'Searchbar',
@@ -121,12 +241,48 @@ export default defineComponent({
 	},
 
 	setup() {
-		const { t } = useI18n();
-
+		const { t, locale } = useI18n();
+		const visibleSearchfield = ref(true);
 		const searchResultStore = useSearchResultStore();
 		const debounceMechanic = ref(false);
 		const keyStrokeEvent = ref<KeyboardEvent | undefined>(undefined);
 		let AutocompleteTimer: ReturnType<typeof setTimeout>;
+		const searchFormRef = ref<HTMLFormElement | null>(null);
+		const showPortalSelector = ref(false);
+		const selectedPortal = ref('drArchive');
+		const selectButtonRef = ref<HTMLButtonElement | null>(null);
+		const selectorValues: PortalSelectItem[] = [
+			{
+				name: 'drArchive',
+				destination: '',
+			},
+			{
+				name: 'booksAndMaterials',
+				destination:
+					'https://soeg.kb.dk/discovery/search?query=any,contains,sq&tab=Everything&search_scope=MyInst_and_CI&vid=45KBDK_KGL:KGL&lang=',
+			},
+			{
+				name: 'kbdk',
+				destination: 'https://www.kb.dk/search/site?search_api_fulltext=sq&search_type=kbdk',
+			},
+			{
+				name: 'webshop',
+				destination: 'https://webshop.kb.dk/?s=sq&post_type=product',
+			},
+			{
+				name: 'seeAllMaterials',
+				destination: '',
+			},
+		];
+
+		onMounted(() => {
+			window.addEventListener('toggle-search', toggleSearchField);
+			console.log(locale);
+		});
+
+		onUnmounted(() => {
+			window.removeEventListener('toggle-search', toggleSearchField);
+		});
 
 		watch(
 			() => searchResultStore.currentQuery,
@@ -147,53 +303,99 @@ export default defineComponent({
 			},
 		);
 
+		const toggleSearchField = () => {
+			if (visibleSearchfield.value) {
+				gsap.to(searchFormRef.value, {
+					height: '0px',
+					duration: 0.5,
+					overwrite: true,
+					opacity: 1,
+					overflow: 'hidden',
+					onComplete: () => {
+						gsap.set(searchFormRef.value, {
+							display: 'none',
+							overwrite: true,
+						});
+					},
+				});
+			} else {
+				gsap.set(searchFormRef.value, {
+					display: 'block',
+					overwrite: true,
+					onComplete: () => {
+						gsap.to(searchFormRef.value, {
+							height: 'auto',
+							duration: 0.5,
+							overwrite: true,
+							opacity: 1,
+							onComplete: () => {
+								gsap.set(searchFormRef.value, {
+									overflow: 'visible',
+								});
+							},
+						});
+					},
+				});
+			}
+			visibleSearchfield.value = !visibleSearchfield.value;
+		};
+
 		const updateKeystrokeForAutocomplete = (e: KeyboardEvent) => {
 			keyStrokeEvent.value = e;
 		};
 
 		const getAutocompleteResponse = (query: string) => {
-			if (query !== undefined && query.length >= 2 && !searchResultStore.blockAutocomplete) {
+			if (
+				query !== undefined &&
+				query.length >= 2 &&
+				!searchResultStore.blockAutocomplete &&
+				selectedPortal.value === 'drarchive'
+			) {
 				searchResultStore.getAutocompleteResults(query);
 			}
 		};
 
-		const backgroundImage = computed(() => {
-			return new URL(`@/assets/images/_Den_Sorte_Diamant-Laura_Stamer-min.jpg`, import.meta.url).href;
-		});
-
 		const search = () => {
-			searchResultStore.resetAutocomplete();
-			clearTimeout(AutocompleteTimer);
-			debounceMechanic.value = true;
-			setTimeout(() => {
-				debounceMechanic.value = false;
-			}, 500);
-			let query: LocationQueryRaw = {
-				q: searchResultStore.currentQuery,
-				start: 0,
-			};
+			if (selectedPortal.value === 'drArchive') {
+				searchResultStore.resetAutocomplete();
+				clearTimeout(AutocompleteTimer);
+				debounceMechanic.value = true;
+				setTimeout(() => {
+					debounceMechanic.value = false;
+				}, 500);
+				let query: LocationQueryRaw = {
+					q: searchResultStore.currentQuery,
+					start: 0,
+				};
 
-			if (searchResultStore.preliminaryFilter !== '') {
-				query.fq = searchResultStore.preliminaryFilter;
-			}
+				if (searchResultStore.preliminaryFilter !== '') {
+					query.fq = searchResultStore.preliminaryFilter;
+				}
 
-			if (searchResultStore.sort !== '') {
-				query.sort = searchResultStore.sort;
+				if (searchResultStore.sort !== '') {
+					query.sort = searchResultStore.sort;
+				} else {
+					query.sort = encodeURIComponent(`score desc`);
+				}
+
+				router.push({
+					name: 'Search',
+					query: query,
+				});
 			} else {
-				query.sort = encodeURIComponent(`score desc`);
+				let URL = selectorValues.find((item) => item.name === selectedPortal.value)?.destination;
+				if (URL) {
+					URL = URL.replace(/sq/g, encodeURIComponent(searchResultStore.currentQuery));
+					window.location.href = URL;
+				}
 			}
-
-			router.push({
-				name: 'Home',
-				query: query,
-			});
 		};
 
 		const reset = () => {
 			searchResultStore.currentQuery = '';
 			searchResultStore.loading = false;
 			setPreliminaryFilter('');
-			router.push({ name: 'Home' });
+			router.push({ name: 'Search' });
 		};
 
 		const setPreliminaryFilter = (value: string) => {
@@ -203,6 +405,16 @@ export default defineComponent({
 			}
 		};
 
+		const togglePortalSelector = () => {
+			showPortalSelector.value = !showPortalSelector.value;
+		};
+
+		const selectPortal = (selected: number) => {
+			selectedPortal.value = selectorValues[selected].name;
+			togglePortalSelector();
+			(document.querySelector('#focusSearchInput') as HTMLInputElement)?.focus();
+		};
+
 		return {
 			searchResultStore,
 			debounceMechanic,
@@ -210,10 +422,16 @@ export default defineComponent({
 			search,
 			reset,
 			t,
-			backgroundImage,
 			updateKeystrokeForAutocomplete,
 			keyStrokeEvent,
 			addTestDataEnrichment,
+			searchFormRef,
+			togglePortalSelector,
+			showPortalSelector,
+			selectPortal,
+			selectButtonRef,
+			selectedPortal,
+			selectorValues,
 		};
 	},
 });
@@ -284,24 +502,18 @@ input[type='search']::-webkit-search-results-decoration {
 	display: block;
 }
 
+.searchform {
+	overflow: visible;
+}
+
 .search-box {
 	height: 100%;
 	position: relative;
-}
-
-.bg-image {
-	width: 100%;
-	height: 100%;
-	object-fit: cover;
-	position: absolute;
+	z-index: 5;
 }
 
 .btn-icon i {
 	margin-left: auto;
-}
-
-.edge {
-	height: 31px;
 }
 
 .locked input {
@@ -309,23 +521,15 @@ input[type='search']::-webkit-search-results-decoration {
 	cursor: default;
 }
 
-.edge.white {
-	width: 100%;
-	position: absolute;
-	background-color: white;
-	clip-path: polygon(0 0, 0 100%, 100% 100%);
-	margin-top: -30px;
-}
-
 .search-container {
 	display: flex;
 	height: 100%;
-	background-image: url('https://design.kb.dk/components/assets/images/sourcesets/2/1280x560px_a.jpg');
 	align-content: center;
 	justify-content: center;
 	align-items: center;
 	background-size: cover;
 	background-position: center;
+	background-color: #caf0fe;
 }
 
 .btn-icon {
@@ -511,6 +715,207 @@ input:focus {
 .d-none {
 	display: none;
 }
+
+.btn-outline-primary:focus,
+.btn-outline-primary.focus {
+	box-shadow: 0 0 0 0.2rem rgba(0, 46, 112, 0.5);
+}
+
+.bootstrap-select {
+	width: auto;
+	min-width: 220px;
+	margin-bottom: 0;
+	position: relative;
+	vertical-align: middle;
+
+	width: 100%;
+	border: 1px solid black;
+	height: 48px;
+	margin-bottom: 26px;
+	border-radius: 0.25rem;
+}
+
+.selectpicker {
+	position: absolute !important;
+	bottom: 0;
+	left: 50%;
+	display: block !important;
+	width: 0.5px !important;
+	height: 100% !important;
+	padding: 0 !important;
+	opacity: 0 !important;
+	border: none;
+	z-index: 0 !important;
+}
+
+.dropdown-toggle {
+	position: relative;
+	width: 100%;
+	text-align: right;
+	white-space: nowrap;
+	display: inline-flex;
+	align-items: center;
+	justify-content: space-between;
+	border-radius: 2px;
+	padding: 0.375rem 0.75rem;
+	height: 3rem;
+	font-size: 1rem;
+	line-height: 2.25rem;
+	margin-bottom: 0;
+	padding: 20px 12px;
+	height: 72px;
+	border: none;
+	background: white;
+	font-family: 'noway', sans-serif;
+	cursor: pointer;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	color: #002e70;
+
+	width: 100%;
+	padding: 6px 12px;
+	height: auto;
+}
+
+.dropdown-toggle::after {
+	vertical-align: middle;
+	margin-left: 1rem;
+	border: none;
+	content: 'expand_more';
+	font-family: 'Material Icons', serif;
+	font-weight: normal;
+	font-style: normal;
+	font-size: 24px;
+	display: inline-block;
+	line-height: 1;
+	text-transform: none;
+	letter-spacing: normal;
+	word-wrap: normal;
+	white-space: nowrap;
+	direction: ltr;
+	-webkit-font-smoothing: antialiased;
+	text-rendering: optimizeLegibility;
+	-moz-osx-font-smoothing: grayscale;
+	font-feature-settings: 'liga';
+}
+
+.filter-option {
+	position: static;
+	top: 0;
+	left: 0;
+	float: left;
+	height: 100%;
+	width: 100%;
+	text-align: left;
+	overflow: hidden;
+	flex: 0 1 auto;
+}
+
+.dropdown-item {
+	display: block;
+	width: 100%;
+	padding: 0.75rem 0.75rem;
+	clear: both;
+	font-weight: 400;
+	color: #171717;
+	text-align: inherit;
+	text-decoration: none;
+	white-space: nowrap;
+	background-color: transparent;
+	border: 0;
+}
+
+.dropdown-menu {
+	position: absolute;
+	top: 100%;
+	left: 0;
+	z-index: 5;
+	display: none;
+	float: left;
+	min-width: 10rem;
+	padding: 0 0;
+	margin: 0.125rem 0 0;
+	font-size: 1rem;
+	color: #212529;
+	text-align: left;
+	list-style: none;
+	background-color: #fff;
+	background-clip: padding-box;
+	border: 1px solid rgba(0, 0, 0, 0.15);
+	border-radius: 0.125rem;
+	min-width: 100%;
+}
+
+.dropdown-menu-inner {
+	position: absolute;
+	top: 100%;
+	left: 0;
+	z-index: 5;
+	float: left;
+	min-width: 10rem;
+	padding: 0 0;
+	margin: 0.125rem 0 0;
+	font-size: 1rem;
+	color: #212529;
+	text-align: left;
+	list-style: none;
+	background-color: #fff;
+	background-clip: padding-box;
+	border: 1px solid #f5f5f5;
+	border-radius: 0.125rem;
+	min-width: 100%;
+	margin-left: -2px;
+	top: -2px;
+	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.12);
+}
+
+.dropdown-menu-inner button,
+.dropdown-menu-inner a {
+	font-family: 'noway', sans-serif;
+	font-size: 16px;
+	transition: all 0.3s linear 0s;
+}
+
+.dropdown-menu-inner button:hover,
+.dropdown-menu-inner a:hover {
+	color: #002e70;
+	background-color: #f2f4f8;
+	cursor: pointer;
+}
+
+.dropdown-menu.select-show {
+	display: block;
+}
+#bs-select-1-3 {
+	border-top: 1px solid #d6d6d6;
+}
+
+#bs-select-1-3:after {
+	content: 'link';
+	float: right;
+	line-height: 1.5rem;
+	font-family: 'Material Icons';
+	font-size: 24px;
+	transform: translate(-100%, 0px);
+}
+
+.bootstrap-select .dropdown-menu li {
+	position: relative;
+	padding: 0;
+	margin: 0;
+	overflow: hidden;
+}
+
+.bootstrap-select .dropdown-menu.inner {
+	position: static;
+	float: none;
+	border: 0;
+	padding: 0;
+	margin: 0;
+	border-radius: 0;
+	box-shadow: none;
+}
+
 /* MEDIA QUERY 480 */
 @media (min-width: 480px) {
 	.container {
@@ -526,6 +931,21 @@ input:focus {
 	.container {
 		max-width: 990px;
 	}
+
+	.bootstrap-select {
+		width: calc(50% - 10px);
+		box-sizing: border-box;
+	}
+
+	.dropdown-toggle {
+		height: 46px;
+	}
+
+	#searchButton {
+		width: calc(50% - 10px);
+		box-sizing: border-box;
+		height: 48px;
+	}
 }
 /* MEDIA QUERY 800 */
 @media (min-width: 800px) {
@@ -536,6 +956,26 @@ input:focus {
 		margin-top: initial;
 		position: initial;
 		width: 48px;
+	}
+
+	#searchButton {
+		width: auto;
+		height: auto;
+	}
+
+	.dropdown-toggle {
+		height: 72px;
+		padding: 20px 12px;
+	}
+
+	.dropdown-menu {
+		top: 71px;
+	}
+
+	.bootstrap-select {
+		border: 0px;
+		margin-bottom: 0px;
+		width: auto;
 	}
 
 	.btn-icon i {

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -277,7 +277,6 @@ export default defineComponent({
 
 		onMounted(() => {
 			window.addEventListener('toggle-search', toggleSearchField);
-			console.log(locale);
 		});
 
 		onUnmounted(() => {
@@ -395,7 +394,7 @@ export default defineComponent({
 			searchResultStore.currentQuery = '';
 			searchResultStore.loading = false;
 			setPreliminaryFilter('');
-			router.push({ name: 'Search' });
+			router.push({ name: 'Home' });
 		};
 
 		const setPreliminaryFilter = (value: string) => {

--- a/src/components/search/SearchOverhead.vue
+++ b/src/components/search/SearchOverhead.vue
@@ -204,9 +204,9 @@ export default defineComponent({
 
 		const resetFilters = () => {
 			searchResultStore.setKeepFacets(false);
+			searchResultStore.resetSearch();
 			router.push({
 				name: 'Home',
-				query: { q: searchResultStore.currentQuery },
 			});
 		};
 

--- a/src/components/search/SearchOverhead.vue
+++ b/src/components/search/SearchOverhead.vue
@@ -341,6 +341,11 @@ export default defineComponent({
 	padding-left: 2px;
 }
 
+.hit-count {
+	z-index: 0;
+	position: relative;
+}
+
 .display-option.active {
 	border-bottom: 2px solid #002e70;
 	box-sizing: border-box;
@@ -382,7 +387,7 @@ export default defineComponent({
 	align-items: center;
 	justify-content: flex-end;
 	min-height: 47px;
-	z-index: 1;
+	z-index: 0;
 	position: relative;
 	padding-top: 25px;
 }
@@ -391,7 +396,7 @@ export default defineComponent({
 	position: relative;
 	display: flex;
 	justify-content: space-between;
-	z-index: 5;
+	z-index: 0;
 	flex-direction: column-reverse;
 }
 
@@ -401,6 +406,8 @@ export default defineComponent({
 	align-items: center;
 	justify-content: flex-end;
 	flex-direction: column-reverse;
+	z-index: 1;
+	position: relative;
 }
 
 .filter-options.disabled button {

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -16,6 +16,13 @@
    "frontpage": {
       "fromTheArchive":"Et udpluk fra arkivet"
    },
+   "breadcrumb": {
+      "frontpage":"Forside",
+      "findMaterials": "Find materiale",
+      "drArchive": "DR-Arkivet",
+      "search":"Søgning",
+      "record": "Fuldpost"
+   },
    "timeSearch": {
       "timeMachine":"Brug Tiden...",
       "year":"år | år",
@@ -35,11 +42,11 @@
       "result":"resultat | resultater",
       "all":"alle",
       "allMonths":"alle måneder i perioden",
-      "allDays":"alle udedage i perioden",
+      "allDays":"alle ugedage i perioden",
       "allTimeslots":"hele døgnet",
       "selection":"Et udpluk af resultaterne",
       "monthHeadline":"Udvælg måneder",
-      "dayHeadline":"Udvælg udedage",
+      "dayHeadline":"Udvælg ugedage",
       "timeslotHeadline":"Udvælg tidspunkter",
       "yearHeadline":"Vælg dato via kalender",
       "filterOpenButton":"Tidspunkter",
@@ -102,8 +109,20 @@
      "thumbnailButton":"Se flere thumbnails",
      "thumbnailLink": "Thumbnail {index} ved {timestamp}",
      "of":"af",
-     "startTime":"starttid"
-
+     "startTime":"starttid",
+     "portals": {
+         "drArchive":"DR Arkivet",
+         "booksAndMaterials":"Bøger og tidskrifter",
+         "kbdk":"Søg på kb.dk",
+         "webshop":"Webshop",
+         "seeAllMaterials":"Se alt materiale"
+      },
+      "placeholders": {
+         "drArchive":"Søg i  DR arkiv",
+         "booksAndMaterials":"Søg på titel, forfatter, tidsskrift, database etc.",
+         "kbdk":"Søg i hjemmesiden",
+         "webshop":"Søg i webshoppen"
+      }
    },
   "record":{
      "duration":"Varighed",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,13 @@
    "frontpage": {
       "fromTheArchive":"A selection from the archive"
    },
+   "breadcrumb": {
+      "frontpage":"Frontpage",
+      "findMaterials": "Find materials",
+      "drArchive": "DR-archive",
+      "search":"Search",
+      "record": "Fullpost"
+   },
    "timeSearch": {
       "timeMachine":"Use the time...",
       "year":"year | years",
@@ -102,7 +109,21 @@
      "thumbnailButton":"See more thumbnails",
      "thumbnailLink": "Thumbnail {index} at {timestamp}",
      "of":"of",
-     "startTime":"Start time"
+     "startTime":"Start time",
+     "portals": {
+         "drArchive":"DR Archive",
+         "booksAndMaterials":"Books and journals",
+         "kbdk":"Search kb.dk",
+         "webshop":"Webshop",
+         "seeAllMaterials":"See all materials"
+      },
+      "placeholders": {
+         "drArchive":"Search DR Archive",
+         "booksAndMaterials":"Search title, author, journal, database etc. ",
+         "kbdk":"Search on website",
+         "webshop":"Search in our webshop",
+         "seeAllMaterials":"See all materials"
+      }
   },
   "record":{
      "duration":"Duration",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,10 +1,16 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
 import Search from '../views/Search.vue';
+import Home from '../views/Home.vue';
 
 const routes: Array<RouteRecordRaw> = [
 	{
 		path: '/',
 		name: 'Home',
+		component: Home,
+	},
+	{
+		path: '/find',
+		name: 'Search',
 		component: Search,
 	},
 	{

--- a/src/types/SearchBarTypes.ts
+++ b/src/types/SearchBarTypes.ts
@@ -1,0 +1,4 @@
+export interface PortalSelectItem {
+	name: string;
+	destination: string;
+}

--- a/src/utils/test-enrichments.ts
+++ b/src/utils/test-enrichments.ts
@@ -10,4 +10,4 @@ const santizeAndSimplify = (str: string) => {
 		.replace(/[^a-z0-9-]/g, ''); // Remove any non-alphanumeric chars except hyphens
 };
 
-export { addTestDataEnrichment };
+export { addTestDataEnrichment, santizeAndSimplify };

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,10 +1,8 @@
 <template>
 	<div class="home-container">
-		<div class="container">
+		<div>
 			<Hero />
-			<div>
-				<PortalContent />
-			</div>
+			<PortalContent />
 		</div>
 		<Footer />
 	</div>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,0 +1,94 @@
+<template>
+	<div class="home-container">
+		<div class="container">
+			<Hero />
+			<div>
+				<PortalContent />
+			</div>
+		</div>
+		<Footer />
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import { useSearchResultStore } from '@/store/searchResultStore';
+import PortalContent from '@/components/common/PortalContent.vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter, useRoute } from 'vue-router';
+import Footer from '@/components/global/nav/Footer.vue';
+import Hero from '@/components/search/Hero.vue';
+
+export default defineComponent({
+	name: 'Home',
+	components: {
+		PortalContent,
+		Footer,
+		Hero,
+	},
+
+	setup() {
+		const searchContainer = ref<HTMLElement | null>(null);
+		const searchResultStore = useSearchResultStore();
+
+		return {
+			searchResultStore,
+			searchContainer,
+		};
+	},
+});
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only 
+temporary styling until patterns from design system are implemented 
+-->
+<style scoped>
+.container {
+	text-align: left;
+	margin-right: auto;
+	margin-left: auto;
+	box-sizing: border-box;
+	padding-right: 12px;
+	padding-left: 12px;
+	margin-top: -85px;
+}
+
+.home-container {
+	width: 100%;
+}
+/* MEDIA QUERY 480 */
+@media (min-width: 480px) {
+	.container {
+		max-width: 640px;
+		padding-right: 12px;
+		padding-left: 12px;
+	}
+}
+/* MEDIA QUERY 640 */
+@media (min-width: 640px) {
+	.container {
+		max-width: 990px;
+	}
+}
+/* MEDIA QUERY 990 */
+@media (min-width: 990px) {
+	.container {
+		display: flex;
+		flex-direction: column;
+		max-width: 1150px;
+	}
+}
+/* MEDIA QUERY 1150 */
+@media (min-width: 1150px) {
+	.container {
+		max-width: 1280px;
+	}
+}
+/* MEDIA QUERY 1280 */
+@media (min-width: 1280px) {
+	.container {
+		padding-right: 0;
+		padding-left: 0;
+	}
+}
+</style>

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -1,55 +1,42 @@
 <template>
-	<div class="search-and-results">
-		<!-- This is for the search bar -->
-		<div
-			ref="searchContainer"
-			class="search-container"
-		>
-			<div class="mobile-edge edge"></div>
-			<SearchBar />
-		</div>
-		<Transition
-			name="result"
-			mode="out-in"
-		>
-			<!-- This is for the search results / facets / did-you-mean / pager -->
-			<div
-				v-if="searchResultStore.searchResult.length > 0 || searchResultStore.searchFired"
-				key="1"
-				class="overall-container"
+	<div class="search-container">
+		<div class="search-and-results">
+			<Transition
+				name="result"
+				mode="out-in"
 			>
-				<SearchOverhead />
-				<div class="container">
-					<div class="row">
-						<div
-							v-if="searchResultStore.searchResult.length > 0 || searchResultStore.loading"
-							class="search-resultset"
-						>
-							<SearchResults
-								:search-results="searchResultStore.searchResult"
-								:num-found="searchResultStore.numFound"
+				<!-- This is for the search results / facets / did-you-mean / pager -->
+				<div
+					v-if="searchResultStore.searchResult.length > 0 || searchResultStore.searchFired"
+					key="1"
+					class="overall-container"
+				>
+					<SearchOverhead />
+					<div class="container">
+						<div class="row">
+							<div
+								v-if="searchResultStore.searchResult.length > 0 || searchResultStore.loading"
+								class="search-resultset"
+							>
+								<SearchResults
+									:search-results="searchResultStore.searchResult"
+									:num-found="searchResultStore.numFound"
+								/>
+							</div>
+							<div v-if="searchResultStore.searchResult.length == 0 && !searchResultStore.loading">
+								<NoHits />
+							</div>
+							<Pagination
+								v-show="searchResultStore.searchResult.length > 0"
+								:items-per-page="Number(searchResultStore.rowCount)"
+								:total-hits="searchResultStore.numFound"
+								:num-pages-to-show="numPagesToShow"
 							/>
 						</div>
-						<div v-if="searchResultStore.searchResult.length == 0 && !searchResultStore.loading">
-							<NoHits />
-						</div>
-						<Pagination
-							v-show="searchResultStore.searchResult.length > 0"
-							:items-per-page="Number(searchResultStore.rowCount)"
-							:total-hits="searchResultStore.numFound"
-							:num-pages-to-show="numPagesToShow"
-						/>
 					</div>
 				</div>
-			</div>
-			<!-- This for the portal content when no search has been fired -->
-			<div
-				v-else
-				key="2"
-			>
-				<PortalContent v-if="!searchResultStore.searchFired" />
-			</div>
-		</Transition>
+			</Transition>
+		</div>
 		<Footer />
 	</div>
 </template>
@@ -58,10 +45,7 @@
 import { defineComponent, ref, onMounted, watch, inject } from 'vue';
 import { useSearchResultStore } from '@/store/searchResultStore';
 import SearchResults from '@/components/search/SearchResults.vue';
-import SearchBar from '@/components/search/SearchBar.vue';
-import PortalContent from '@/components/common/PortalContent.vue';
 import { useI18n } from 'vue-i18n';
-import gsap from 'gsap';
 import { useRouter, useRoute, RouteLocationNormalizedLoaded } from 'vue-router';
 import Pagination from '@/components/search/Pager.vue';
 import SearchOverhead from '@/components/search/SearchOverhead.vue';
@@ -74,17 +58,13 @@ export default defineComponent({
 	name: 'Search',
 	components: {
 		SearchResults,
-		SearchBar,
 		Pagination,
 		SearchOverhead,
-		PortalContent,
 		NoHits,
 		Footer,
 	},
 
 	setup() {
-		const searchContainer = ref<HTMLElement | null>(null);
-
 		const searchResultStore = useSearchResultStore();
 		const router = useRouter();
 		const route = useRoute();
@@ -99,9 +79,6 @@ export default defineComponent({
 			document.title = t('app.titles.frontpage.archive.name') as string;
 			searchResultStore.resetFilters();
 			if (route.query.q !== undefined) {
-				gsap.set(searchContainer.value, {
-					height: '300px',
-				});
 				const routeFacetQueries = route.query.fq;
 				const start = route.query.start as string;
 				const sort = route.query.sort as string;
@@ -138,20 +115,8 @@ export default defineComponent({
 					t('app.titles.frontpage.archive.suffix')) as string;
 			} else if (route.query.q === undefined) {
 				searchResultStore.resetSearch();
-				gsap.to(searchContainer.value, { height: '500px', duration: '0.4' });
 			}
 		});
-
-		watch(
-			() => searchResultStore.searchResult.length,
-			(newn: number) => {
-				if (newn > 0) {
-					gsap.to(searchContainer.value, { height: '300px', duration: '0.4' });
-				} else {
-					gsap.to(searchContainer.value, { height: '500px', duration: '0.4' });
-				}
-			},
-		);
 
 		// Watch the url param and update search results if it changes
 		watch(
@@ -218,7 +183,6 @@ export default defineComponent({
 
 		return {
 			searchResultStore,
-			searchContainer,
 			numPagesToShow,
 		};
 	},
@@ -284,26 +248,12 @@ h3 {
 	max-width: 100%;
 }
 .search-container {
-	width: 100vw;
-	max-width: 100%;
-	height: 500px;
+	width: 100%;
 }
 
-.search-container.big {
-	height: 500px;
-}
-
-.search-container.small {
-	height: 300px;
-}
 .search-resultset {
 	display: flex;
 	flex-direction: column;
-}
-
-.hit-count {
-	padding-top: 40px;
-	padding-bottom: 40px;
 }
 
 .container {

--- a/src/views/ShowRecord.vue
+++ b/src/views/ShowRecord.vue
@@ -141,7 +141,7 @@ export default defineComponent({
 .top-offset {
 	position: relative;
 	background: white;
-	top: -20px;
+	top: -6vw;
 	z-index: 3;
 }
 /* MEDIA QUERY 480 */
@@ -167,7 +167,7 @@ export default defineComponent({
 		max-width: 1150px;
 	}
 	.top-offset {
-		top: -58px;
+		top: -6vw;
 		margin-left: 24px;
 		margin-right: 24px;
 	}


### PR DESCRIPTION
Drastic rework with the following:

Hero search field removed.
Reworked menu to add kb searchfield to the header menu - added search toggle on mobile menu
Added dropdown for different portals
Added Breadcrumb for the entire application
Changed kb logo to link to kb.dk instead of application frontpage
Added a /find subpage for the search results.
