### PR TITLE
DRA-optional: Bug-fixing

### DIFF
--- a/src/assets/styles/vue-slider-styles.css
+++ b/src/assets/styles/vue-slider-styles.css
@@ -124,17 +124,17 @@
 	}
 }
 
-.vue-slider-marks .vue-slider-mark:nth-child(5n) .vue-slider-mark-label {
+.vue-slider-marks .vue-slider-mark:nth-child(1n) .vue-slider-mark-label {
 	display: block;
 	color: #002e70;
 }
 
-.vue-slider-marks .vue-slider-mark:nth-child(5n) {
+.vue-slider-marks .vue-slider-mark:nth-child(1n) {
 	height: 50% !important;
 	top: 75% !important;
 }
 
-.vue-slider-marks .vue-slider-mark:nth-child(5n) .vue-slider-mark-step:after {
+.vue-slider-marks .vue-slider-mark:nth-child(1n) .vue-slider-mark-step:after {
 	content: '';
 	display: block;
 	width: 20px;

--- a/src/components/common/SkewedFoldable.vue
+++ b/src/components/common/SkewedFoldable.vue
@@ -246,7 +246,6 @@ h1::first-letter {
 .content .mobile-title {
 	border: 0px;
 	background-color: transparent;
-	width: 100%;
 	display: flex;
 	align-items: center;
 	cursor: pointer;
@@ -394,6 +393,9 @@ h1::first-letter {
 @media (min-width: 990px) {
 	.toggle-button {
 		display: none;
+	}
+	.mobile-title {
+		width: 100%;
 	}
 
 	h1 {

--- a/src/components/common/TimeSearchComponent.vue
+++ b/src/components/common/TimeSearchComponent.vue
@@ -114,6 +114,7 @@ export default defineComponent({
 				fq: [],
 			},
 		});
+
 		const fetchNewTimeResults = () => {
 			updateLink();
 			getTimeResults(true);

--- a/src/components/common/timeSearch/DayPicker.vue
+++ b/src/components/common/timeSearch/DayPicker.vue
@@ -40,10 +40,19 @@
 <script lang="ts">
 import { defineComponent, onMounted, ref } from 'vue';
 import VueDatePicker from '@vuepic/vue-datepicker';
-import { startYear, endYear, startDate, endDate } from '@/components/common/timeSearch/TimeSearchInitValues';
+import {
+	startYear,
+	endYear,
+	startDate,
+	endDate,
+	months,
+	days,
+	timeslots,
+} from '@/components/common/timeSearch/TimeSearchInitValues';
 import type { DatePickerInstance } from '@vuepic/vue-datepicker';
 import { RouteLocationRaw } from 'vue-router';
 import { addTestDataEnrichment } from '@/utils/test-enrichments';
+import { resetAllSelectorValues } from '@/utils/time-search-utils';
 
 interface MonthYearEvent {
 	instance: number;
@@ -58,10 +67,10 @@ export default defineComponent({
 	},
 	setup() {
 		const singleDatePicker = ref<DatePickerInstance>();
-		const selectedDate = ref(new Date(1992, 0, 1, 0, 0, 0));
+		const selectedDate = ref(new Date(2015, 0, 1, 0, 0, 0));
 
-		const singleDayStartDate = ref<Date>(new Date(1992, 0, 1, 0, 0, 0)); // January 1, 1992, 00:00:00
-		const singleDayEndDate = ref<Date>(new Date(1992, 0, 1, 23, 59, 59)); // January 1, 1992, 23:59:59
+		const singleDayStartDate = ref<Date>(new Date(2015, 0, 1, 0, 0, 0)); // January 1, 2015, 00:00:00
+		const singleDayEndDate = ref<Date>(new Date(2015, 0, 1, 23, 59, 59)); // January 1, 2015, 23:59:59
 
 		const format = (date: Date) => {
 			const day = date.getDate();
@@ -89,6 +98,10 @@ export default defineComponent({
 			endDate.value.setFullYear(selectedDate.value.getFullYear());
 			endDate.value.setMonth(selectedDate.value.getMonth());
 			endDate.value.setDate(selectedDate.value.getDate());
+
+			resetAllSelectorValues(months.value);
+			resetAllSelectorValues(days.value);
+			resetAllSelectorValues(timeslots.value);
 		};
 
 		const updateSeeMoreLink = () => {

--- a/src/components/common/timeSearch/DayPicker.vue
+++ b/src/components/common/timeSearch/DayPicker.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from 'vue';
+import { defineComponent, onMounted, ref } from 'vue';
 import VueDatePicker from '@vuepic/vue-datepicker';
 import { startYear, endYear, startDate, endDate } from '@/components/common/timeSearch/TimeSearchInitValues';
 import type { DatePickerInstance } from '@vuepic/vue-datepicker';
@@ -126,6 +126,10 @@ export default defineComponent({
 			selectedDate.value = holder;
 			updateSeeMoreLink();
 		};
+
+		onMounted(() => {
+			updateSeeMoreLink();
+		});
 
 		return {
 			singleDatePicker,

--- a/src/components/common/timeSearch/TimeSearchFilters.vue
+++ b/src/components/common/timeSearch/TimeSearchFilters.vue
@@ -264,6 +264,8 @@ import {
 	timeslots,
 	startDate,
 	endDate,
+	initEndDate,
+	initStartDate,
 	initSliderValues,
 	startYear,
 	endYear,
@@ -336,7 +338,10 @@ export default defineComponent({
 				resetAllSelectorValues(days.value);
 				resetAllSelectorValues(timeslots.value);
 				timeSliderValues.value = initSliderValues.value;
-
+				const holder = new Date(initEndDate.value.getTime());
+				endDate.value = holder;
+				const holder2 = new Date(initStartDate.value.getTime());
+				startDate.value = holder2;
 				getTimeResults(true);
 			}
 			if (props.timeline) {

--- a/src/components/common/timeSearch/TimeSearchInitValues.ts
+++ b/src/components/common/timeSearch/TimeSearchInitValues.ts
@@ -1,17 +1,17 @@
 import { SelectorData } from '@/types/TimeSearchTypes';
 import { ref } from 'vue';
 
-const initSliderValues = ref<number[]>([1992, 1992]);
-const initStartDate = ref<Date>(new Date(1992, 0, 1, 0, 0, 0)); // January 1, 1992, 00:00:00
-const initEndDate = ref<Date>(new Date(1992, 11, 31, 23, 59, 59)); // December 31, 1992, 23:59:59
+const initSliderValues = ref<number[]>([2015, 2015]);
+const initStartDate = ref<Date>(new Date(2015, 0, 1, 0, 0, 0)); // January 1, 2015, 00:00:00
+const initEndDate = ref<Date>(new Date(2015, 11, 31, 23, 59, 59)); // December 31, 2015, 23:59:59
 
 const timeSliderValues = ref<number[]>(initSliderValues.value);
-const startDate = ref<Date>(initStartDate.value); // January 1, 1992, 00:00:00
-const endDate = ref<Date>(initEndDate.value); // December 31, 1992, 23:59:59
+const startDate = ref<Date>(initStartDate.value); // January 1, 2015, 00:00:00
+const endDate = ref<Date>(initEndDate.value); // December 31, 2015, 23:59:59
 
 /* these are just the preset values. Should be updated when we got the new index in solr */
-const startYear = ref<Date>(new Date(1921, 0, 1, 0, 0, 0));
-const endYear = ref<Date>(new Date(2022, 11, 31, 23, 59, 59));
+const startYear = ref<Date>(new Date(2006, 0, 1, 0, 0, 0));
+const endYear = ref<Date>(new Date(2024, 11, 31, 23, 59, 59));
 
 const days = ref<SelectorData[]>([
 	{ name: 'timeSearch.weekdays.monday', value: 'Monday', selected: false, index: 0 },

--- a/src/components/records/BroadcastAudioRecord.vue
+++ b/src/components/records/BroadcastAudioRecord.vue
@@ -20,11 +20,11 @@
 			<div class="right-side">
 				<div class="right-side-metadata-box">
 					<h3>Sendt</h3>
-					<div>
+					<div class="info">
 						<span class="material-icons blue">event</span>
 						{{ getBroadcastDate(recordData.startTime, locale) }}
 					</div>
-					<div>
+					<div class="info">
 						<span class="material-icons blue">schedule</span>
 						Kl. {{ getBroadcastTime(recordData.startTime) }} - {{ getBroadcastTime(recordData.endTime) }}
 						<span class="broadcast-duration">
@@ -35,12 +35,27 @@
 							></duration>
 						</span>
 					</div>
-					<div>
+					<div class="info">
 						<span class="material-icons blue">tv</span>
 						{{ recordData.publication.publishedOn.broadcastDisplayName }}
 					</div>
 					<h4>{{ $t('record.genre') }}</h4>
-					<div>{{ recordData.keywords }}</div>
+					<div>
+						<router-link
+							:to="{
+								name: 'Search',
+								query: {
+									q: '*:*',
+									start: 0,
+									fq: [encodeURIComponent(`genre:${quotation(recordData.genre)}`)],
+								},
+							}"
+							class="genre-link"
+							:data-testid="addTestDataEnrichment('link', 'boardcast-record-audio', `genre-link`, 0)"
+						>
+							{{ recordData.genre }}
+						</router-link>
+					</div>
 				</div>
 				<div class="divider darkblue"></div>
 				<button
@@ -147,6 +162,10 @@ export default defineComponent({
 			copyTextToClipboard();
 		};
 
+		const quotation = (name: string) => {
+			return `"${name}"`;
+		};
+
 		return {
 			lastPath,
 			locale,
@@ -157,6 +176,7 @@ export default defineComponent({
 			getBroadcastTime,
 			checkForKalturaId,
 			addTestDataEnrichment,
+			quotation,
 		};
 	},
 });
@@ -174,6 +194,12 @@ temporary styling until patterns from design system are implemented
 .back-link {
 	width: 100%;
 	margin-bottom: 10px;
+}
+
+.info {
+	display: flex;
+	align-items: center;
+	gap: 7px;
 }
 
 .no-streaming {
@@ -298,6 +324,11 @@ temporary styling until patterns from design system are implemented
 .related-record {
 	flex: 0 0 90%;
 	box-sizing: border-box;
+}
+
+.genre-link {
+	color: #002e70;
+	text-decoration: none;
 }
 
 /* First breakpoint for tablet */

--- a/src/components/records/BroadcastVideoRecord.vue
+++ b/src/components/records/BroadcastVideoRecord.vue
@@ -21,11 +21,11 @@
 			<div class="right-side">
 				<div class="right-side-metadata-box">
 					<h3>Sendt</h3>
-					<div>
+					<div class="info">
 						<span class="material-icons blue">event</span>
 						{{ getBroadcastDate(recordData.startTime, locale) }}
 					</div>
-					<div>
+					<div class="info">
 						<span class="material-icons blue">schedule</span>
 						Kl. {{ getBroadcastTime(recordData.startTime) }} - {{ getBroadcastTime(recordData.endTime) }}
 						<span class="broadcast-duration">
@@ -36,12 +36,27 @@
 							></duration>
 						</span>
 					</div>
-					<div>
+					<div class="info">
 						<span class="material-icons blue">tv</span>
 						{{ recordData.publication.publishedOn.broadcastDisplayName }}
 					</div>
 					<h4>{{ $t('record.genre') }}</h4>
-					<div>{{ recordData.keywords }}</div>
+					<div>
+						<router-link
+							:to="{
+								name: 'Search',
+								query: {
+									q: '*:*',
+									start: 0,
+									fq: [encodeURIComponent(`genre:${quotation(recordData.genre)}`)],
+								},
+							}"
+							class="genre-link"
+							:data-testid="addTestDataEnrichment('link', 'boardcast-record-video', `genre-link`, 0)"
+						>
+							{{ recordData.genre }}
+						</router-link>
+					</div>
 				</div>
 				<div class="divider darkblue"></div>
 				<button
@@ -144,6 +159,10 @@ export default defineComponent({
 			copyTextToClipboard();
 		};
 
+		const quotation = (name: string) => {
+			return `"${name}"`;
+		};
+
 		return {
 			lastPath,
 			locale,
@@ -154,6 +173,7 @@ export default defineComponent({
 			getTimeFromISOFormat,
 			entryId,
 			addTestDataEnrichment,
+			quotation,
 		};
 	},
 });
@@ -180,6 +200,12 @@ temporary styling until patterns from design system are implemented
 .video-container {
 	min-height: 300px;
 	width: 100%;
+}
+
+.info {
+	display: flex;
+	align-items: center;
+	gap: 7px;
 }
 
 .no-streaming {
@@ -303,6 +329,11 @@ temporary styling until patterns from design system are implemented
 .related-record {
 	flex: 0 0 90%;
 	box-sizing: border-box;
+}
+
+.genre-link {
+	color: #002e70;
+	text-decoration: none;
 }
 
 /* First breakpoint for tablet */

--- a/src/components/search/CurrentFilters.vue
+++ b/src/components/search/CurrentFilters.vue
@@ -101,16 +101,28 @@
 				</span>
 				<span class="material-icons">close</span>
 			</button>
+			<button
+				v-if="searchResultStore.preliminaryFilter !== ''"
+				key="5"
+				@click="removePreliminaryFilterAndSearch()"
+			>
+				<span>
+					{{
+						`${decodeURIComponent(searchResultStore.preliminaryFilter).split(':')[1].replaceAll('"', '').split('.')[1]}`
+					}}
+				</span>
+				<span class="material-icons">close</span>
+			</button>
 			<span
 				v-if="filtersActive"
-				key="5"
+				key="6"
 				class="seperator"
 			>
 				|
 			</span>
 			<button
 				v-if="filtersActive"
-				key="6"
+				key="7"
 				class="resetFilters"
 				@click="resetAllFilters"
 			>
@@ -158,7 +170,8 @@ export default defineComponent({
 					searchResultStore.categoryFilters.length !== 0 ||
 					searchResultStore.channelFilters.length !== 0 ||
 					startDate.value.getTime() !== startYear.value.getTime() ||
-					endDate.value.getTime() !== endYear.value.getTime()) &&
+					endDate.value.getTime() !== endYear.value.getTime() ||
+					searchResultStore.preliminaryFilter !== '') &&
 				!timeSearchStore.newSearchReqMet
 			) {
 				return true;
@@ -176,6 +189,18 @@ export default defineComponent({
 			startDate.value.setTime(startYear.value.getTime());
 			endDate.value.setTime(endYear.value.getTime());
 			removeFilterAndSearch(facet);
+		};
+
+		const removePreliminaryFilterAndSearch = () => {
+			searchResultStore.preliminaryFilter = '';
+			const routeQueries = cloneRouteQuery(route);
+			let fq = normalizeFq(routeQueries.fq);
+			fq = fq.filter((query) => !query.includes('origin'));
+			routeQueries.fq = fq;
+			router.push({
+				name: 'Search',
+				query: routeQueries,
+			});
 		};
 
 		const removeFilterAndSearch = (facet: string) => {
@@ -216,6 +241,7 @@ export default defineComponent({
 			resetAllFilters,
 			removeFilterAndSearch,
 			resetYearsAndSearch,
+			removePreliminaryFilterAndSearch,
 			startDate,
 			endDate,
 			startYear,

--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -256,7 +256,7 @@ export default defineComponent({
 		};
 
 		onMounted(() => {
-			const filters = route.query.fq as string[];
+			const filters = normalizeFq(route.query.fq as string[]);
 			if (Array.isArray(filters) && filters.some((str) => str.includes('startTime'))) {
 				const years = filters.filter((str) => str.includes('startTime'));
 				const splitYears = decodeURIComponent(years[0]).replace('startTime:', '').replace(/[[\]]/g, '').split(' TO ');

--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -59,6 +59,11 @@
 									:headline="$t('facets.choose') + ' ' + $t('facets.genres', 2)"
 									icon="category"
 									:subline="`${getSublineForFacets(genreArray, 'facets.genres', 'facets.allGenres')}`"
+									:item-array="genreArray"
+									:use-headline-translation="false"
+									:update-entity="updateFacet"
+									:filter-name-cutoff="5"
+									:facet-type="'genre'"
 								>
 									<fieldset
 										v-if="searchResultStore.firstBackendFetchExecuted"
@@ -202,7 +207,7 @@ export default defineComponent({
 		const channelsArray = ref([] as SelectorData[]);
 		const genreArray = ref([] as SelectorData[]);
 
-		if (searchResultStore.firstBackendFetchExecuted) {
+		if (searchResultStore.firstBackendFetchExecuted && Object.keys(searchResultStore.initFacets).length !== 0) {
 			channelsArray.value = extendFacetPairToSelectorData(
 				simplifyFacets(searchResultStore.initFacets.facet_fields.creator_affiliation_facet),
 			);
@@ -255,39 +260,73 @@ export default defineComponent({
 			}
 		};
 
-		onMounted(() => {
-			const filters = normalizeFq(route.query.fq as string[]);
-			if (Array.isArray(filters) && filters.some((str) => str.includes('startTime'))) {
-				const years = filters.filter((str) => str.includes('startTime'));
-				const splitYears = decodeURIComponent(years[0]).replace('startTime:', '').replace(/[[\]]/g, '').split(' TO ');
-				const yh = new Date(splitYears[0]);
-				const eh = new Date(splitYears[1]);
-				startDate.value = yh;
-				endDate.value = eh;
-				timeSearchStore.timeFacetsOpen = true;
-				toggleTimeFacets();
-				timeSearchStore.setNewSearchReqMet(false);
-			} else {
-				timeSearchStore.timeFacetsOpen = false;
-				const startHolder = new Date(startYear.value.getTime());
-				const endHolder = new Date(endYear.value.getTime());
-				startDate.value = startHolder;
-				endDate.value = endHolder;
-			}
-			watch(
-				() => searchResultStore.facetResult,
-				(newFacets: FacetResultType) => {
-					currentFacets.value = {} as FacetResultType;
-					channelFacets.value = [] as FacetPair[];
-					categoryFacets.value = [] as FacetPair[];
-					currentFacets.value = newFacets;
-					channelFacets.value = simplifyFacets(newFacets['creator_affiliation_facet']);
-					categoryFacets.value = simplifyFacets(newFacets['genre']);
-					lastUpdate.value = new Date().getTime();
-				},
-				{ deep: true },
-			);
-		});
+		watch(
+			() => searchResultStore.facetResult,
+			(newFacets: FacetResultType) => {
+				currentFacets.value = {} as FacetResultType;
+				channelFacets.value = [] as FacetPair[];
+				categoryFacets.value = [] as FacetPair[];
+				currentFacets.value = newFacets;
+				channelFacets.value = simplifyFacets(newFacets['creator_affiliation_facet']);
+				categoryFacets.value = simplifyFacets(newFacets['genre']);
+				lastUpdate.value = new Date().getTime();
+			},
+			{ deep: true },
+		);
+
+		watch(
+			() => searchResultStore.categoryFilters,
+			(newA: string[]) => {
+				setCategoryArrayFromStore(newA);
+			},
+		);
+
+		const setCategoryArrayFromStore = (items: string[]) => {
+			genreArray.value.forEach((item) => {
+				item.selected = false;
+			});
+			items.forEach((item) => {
+				let newItem = decodeURIComponent(item).replaceAll('"', '').split(':')[1];
+				const matchedItem = genreArray.value.find((genreItem) => genreItem.name === newItem);
+				if (matchedItem) {
+					matchedItem.selected = true;
+				}
+			});
+		};
+
+		watch(
+			() => searchResultStore.channelFilters,
+			(newA: string[]) => {
+				setChannelArrayFromStore(newA);
+			},
+		);
+
+		const setChannelArrayFromStore = (items: string[]) => {
+			channelsArray.value.forEach((item) => {
+				item.selected = false;
+			});
+			items.forEach((item) => {
+				let newItem = decodeURIComponent(item).replaceAll('"', '').split(':')[1];
+				const matchedItem = channelsArray.value.find((channelItem) => channelItem.name === newItem);
+				if (matchedItem) {
+					matchedItem.selected = true;
+				}
+			});
+		};
+
+		watch(
+			() => searchResultStore.currentQuery,
+			(newQ: string, oldQ: string) => {
+				if (newQ !== oldQ) {
+					genreArray.value.forEach((item) => {
+						item.selected = false;
+					});
+					channelsArray.value.forEach((item) => {
+						item.selected = false;
+					});
+				}
+			},
+		);
 
 		watch(
 			() => searchResultStore.showFacets,
@@ -295,6 +334,16 @@ export default defineComponent({
 				toggleFacets();
 			},
 		);
+
+		onMounted(() => {
+			setCategoryArrayFromStore(searchResultStore.categoryFilters);
+			setChannelArrayFromStore(searchResultStore.channelFilters);
+			if (timeSearchStore.timeFacetsOpen && timeFacetButton.value?.getAttribute('aria-checked') === 'false') {
+				toggleTimeFacets();
+			} else if (!timeSearchStore.timeFacetsOpen && timeFacetButton.value?.getAttribute('aria-checked') === 'true') {
+				toggleTimeFacets();
+			}
+		});
 
 		watch(
 			() => timeSearchStore.timeFacetsOpen,

--- a/src/components/search/NoHits.vue
+++ b/src/components/search/NoHits.vue
@@ -17,7 +17,7 @@
 				{{ $t('search.nohitSubtitle.lastPart') }}
 			</div>
 			<EdgedContentArea
-				v-if="searchResultStore.spellCheck.collations.length > 0"
+				v-if="searchResultStore.spellCheck?.collations.length > 0"
 				:lines="true"
 				:dotted-edges="false"
 				background-color="#c4f1ed"

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -342,6 +342,7 @@ export default defineComponent({
 
 		const search = () => {
 			if (selectedPortal.value === 'drArchive') {
+				searchResultStore.searchResult = [];
 				searchResultStore.resetAutocomplete();
 				clearTimeout(AutocompleteTimer);
 				debounceMechanic.value = true;

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -344,6 +344,8 @@ export default defineComponent({
 			if (selectedPortal.value === 'drArchive') {
 				searchResultStore.searchResult = [];
 				searchResultStore.resetAutocomplete();
+				searchResultStore.channelFilters = [];
+				searchResultStore.categoryFilters = [];
 				clearTimeout(AutocompleteTimer);
 				debounceMechanic.value = true;
 				setTimeout(() => {

--- a/src/types/BroadcastRecordType.ts
+++ b/src/types/BroadcastRecordType.ts
@@ -10,6 +10,7 @@ export interface BroadcastRecordType {
 	startTime: string;
 	endTime: string;
 	duration: string;
+	genre: string;
 	keywords: string;
 	identifier: IdentifierType[];
 	contentUrl: string;

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -79,7 +79,7 @@ export default defineComponent({
 			// we set the title of the archive here - needed if we go back from a page that sets it otherwise.
 			document.title = t('app.titles.frontpage.archive.name') as string;
 			const pastPage = router.options.history.state.back as string;
-			if (pastPage && pastPage.startsWith('/post/')) {
+			if (pastPage && pastPage.startsWith('/post/') && searchResultStore.searchResult.length !== 0) {
 				document.title = (t('app.titles.search') +
 					'"' +
 					route.query.q +
@@ -116,6 +116,7 @@ export default defineComponent({
 					}
 					if (routeFacetQueries) {
 						searchResultStore.setFiltersFromURL(routeFacetQueries);
+						timeSearchStore.setFiltersFromUrl(routeFacetQueries);
 					}
 					searchResultStore.getSearchResults(route.query.q as string);
 					document.title = (t('app.titles.search') +

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -114,10 +114,8 @@ export default defineComponent({
 							}
 						}
 					}
-					if (routeFacetQueries) {
-						searchResultStore.setFiltersFromURL(routeFacetQueries);
-						timeSearchStore.setFiltersFromUrl(routeFacetQueries);
-					}
+					searchResultStore.setFiltersFromURL(routeFacetQueries as string[]);
+					timeSearchStore.setFiltersFromUrl(routeFacetQueries as string[]);
 					searchResultStore.getSearchResults(route.query.q as string);
 					document.title = (t('app.titles.search') +
 						'"' +
@@ -144,8 +142,8 @@ export default defineComponent({
 					searchResultStore.setSortFromURL(route.query.sort as string);
 					searchResultStore.setCurrentQueryFromURL(route.query.q as string);
 					searchResultStore.setRowCountFromURL(route.query.rows as string);
-					searchResultStore.getSearchResults(route.query.q as string);
 					timeSearchStore.setFiltersFromUrl(route.query.fq as string[]);
+					searchResultStore.getSearchResults(route.query.q as string);
 
 					document.title = (t('app.titles.search') +
 						'"' +


### PR DESCRIPTION
A few bugs found doing the tests (and a few i discovered myself)

- When searching from a fullpost, you now get a new set of results on the new search term.

- Doing a search from the "pick-a-date" component did not always get the filters attached to the query - this should be fixed now.

- Now picking a new month or year in the "pick-a-date" component sets the day to the first, so you don't _have_ to pick a date before doing a search.

- Fixed an error where you could get a weird breaking of the app because a response was not checked if existed before looking into the object.

- Fixed a bug where the values of the startDate and endDate were not reset when returning to the frontpage, thus messing up the timeline component's "go look at this"-link.

- Adjusted slider for new datapoints

- Minor change to titles for skewedFoldable components

- Adjusted start and end date on daypicker

- Fixed links for genre on fullpost

- Added tv/radio current filter options for visiblity

- Fixed a few bugs with reload and back/forth browser compatability