### PR TITLE
DRA-bugfix: error when searching after timesearch.

### DIFF
--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -359,7 +359,7 @@ export default defineComponent({
 				searchResultStore.preliminaryFilter = '';
 
 				query.sort = encodeURIComponent(`score desc`);
-				timeSearchStore.setTimeFacetsOpen(false);
+				//timeSearchStore.setTimeFacetsOpen(false);
 
 				router.push({
 					name: 'Search',

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -359,7 +359,6 @@ export default defineComponent({
 				searchResultStore.preliminaryFilter = '';
 
 				query.sort = encodeURIComponent(`score desc`);
-				//timeSearchStore.setTimeFacetsOpen(false);
 
 				router.push({
 					name: 'Search',

--- a/src/store/searchResultStore.ts
+++ b/src/store/searchResultStore.ts
@@ -279,7 +279,6 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 			comparisonSearchUUID = responseData.data.responseHeader.params.queryUUID || '';
 
 			if (responseMatchesCurrentSearch(comparisonSearchUUID) && searchFired.value) {
-				/* query !== '*:*' ? (currentQuery.value = query) : null; */
 				searchResult.value = responseData.data.response.docs;
 				spellCheck.value = responseData.data.spellcheck;
 				facetResult.value.genre = facetGenreData.data.facet_counts.facet_fields.genre as string[];

--- a/src/store/searchResultStore.ts
+++ b/src/store/searchResultStore.ts
@@ -279,7 +279,7 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 			comparisonSearchUUID = responseData.data.responseHeader.params.queryUUID || '';
 
 			if (responseMatchesCurrentSearch(comparisonSearchUUID) && searchFired.value) {
-				query !== '*:*' ? (currentQuery.value = query) : null;
+				/* query !== '*:*' ? (currentQuery.value = query) : null; */
 				searchResult.value = responseData.data.response.docs;
 				spellCheck.value = responseData.data.spellcheck;
 				facetResult.value.genre = facetGenreData.data.facet_counts.facet_fields.genre as string[];


### PR DESCRIPTION
Was reported by UX - search after something, apply time filters and search again. Before, it did a search on the previous searchterm instead of the new one. Fixed now.