### PR TITLE
DRA-1512: facet call split out from results and more.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -41,7 +41,7 @@
 			class="wipe"
 		>
 			<img
-				title="Royal Danish Library"
+				title="forside"
 				alt="Logo of the Royal Danish Library"
 				:src="getImgServerSrcURL()"
 			/>

--- a/src/components/common/CustomTimelineSelect.vue
+++ b/src/components/common/CustomTimelineSelect.vue
@@ -103,6 +103,7 @@ export default defineComponent({
 	padding: 0px 5px;
 	color: #002e70;
 	padding-right: 10px;
+	background-color: white;
 }
 
 label {

--- a/src/components/common/timeSearch/TimeSearchFilters.vue
+++ b/src/components/common/timeSearch/TimeSearchFilters.vue
@@ -717,14 +717,14 @@ fieldset {
 	pointer-events: none;
 	z-index: 5;
 	left: -1px;
-	background: linear-gradient(-90deg, rgba(215, 255, 98, 0) 0%, rgb(250, 250, 250) 95%);
+	/* background: linear-gradient(-90deg, rgba(215, 255, 98, 0) 0%, rgb(250, 250, 250) 95%); */
 }
 
 .slider-whiteoff-container:after {
 	right: -1px;
 	left: initial;
 	top: 0px;
-	background: linear-gradient(90deg, rgba(215, 255, 98, 0) 0%, rgb(250, 250, 250) 95%);
+	/* background: linear-gradient(90deg, rgba(215, 255, 98, 0) 0%, rgb(250, 250, 250) 95%); */
 }
 
 .figures {

--- a/src/components/global/notification/NotificationItem.vue
+++ b/src/components/global/notification/NotificationItem.vue
@@ -78,7 +78,6 @@ export default defineComponent({
 		let notificationAnimation: null | gsap.core.Tween;
 
 		onMounted(() => {
-			console.log(props.notification);
 			if (!props.notification.userClose) {
 				notificationAnimation = gsap.to(countdown.value, {
 					duration: duration.time,

--- a/src/components/global/notification/NotificationItem.vue
+++ b/src/components/global/notification/NotificationItem.vue
@@ -127,6 +127,10 @@ export default defineComponent({
 	width: 100%;
 }
 
+.single-notification p {
+	white-space: break-spaces;
+}
+
 .title-span {
 	font: normal normal normal 26px/28px Noway;
 	white-space: nowrap;

--- a/src/components/records/BroadcastAudioRecord.vue
+++ b/src/components/records/BroadcastAudioRecord.vue
@@ -19,8 +19,8 @@
 				<div class="back-link">
 					<div class="triangle"></div>
 					<router-link
-						v-if="lastPath"
-						:to="lastPath"
+						v-if="backLink !== '/'"
+						:to="backLink"
 						class="link-container return"
 						:data-testid="addTestDataEnrichment('link', 'broadcast-audio', 'back-link', 0)"
 					>
@@ -116,13 +116,12 @@
 <script lang="ts">
 import { BroadcastRecordType } from '@/types/BroadcastRecordType';
 import { GenericSearchResultType } from '@/types/GenericSearchResultTypes';
-import { defineComponent, onMounted, PropType, ref, watch } from 'vue';
+import { defineComponent, PropType, ref, watch } from 'vue';
 import AudioPlayer from '@/components/viewers/AudioVideo/AudioPlayer.vue';
 import Duration from '@/components/common/Duration.vue';
 import { copyTextToClipboard } from '@/utils/copy-script';
 import { getBroadcastDate, getBroadcastTime } from '@/utils/time-utils';
 import { getEntryId } from '@/utils/record-utils';
-import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { addTestDataEnrichment } from '@/utils/test-enrichments';
 import { useSearchResultStore } from '@/store/searchResultStore';
@@ -151,11 +150,14 @@ export default defineComponent({
 				return [];
 			},
 		},
+		backLink: {
+			type: String as PropType<string>,
+			required: true,
+		},
 	},
 
 	setup(props) {
 		const lastPath = ref('');
-		const router = useRouter();
 		const { locale, t } = useI18n();
 		const searchResultStore = useSearchResultStore();
 
@@ -165,10 +167,6 @@ export default defineComponent({
 		const checkForKalturaId = () => {
 			return props.recordData.identifier.find((obj) => obj.PropertyID === 'KalturaID') !== undefined;
 		};
-
-		onMounted(() => {
-			lastPath.value = router.options.history.state.back as string;
-		});
 
 		const emptySearchResults = () => {
 			searchResultStore.searchResult = [];
@@ -217,7 +215,7 @@ temporary styling until patterns from design system are implemented
 }
 
 .back-link {
-	width: 100%;
+	width: fit-content;
 }
 
 .info {
@@ -395,7 +393,6 @@ temporary styling until patterns from design system are implemented
 	display: flex;
 	flex-direction: row;
 	bottom: 0;
-	width: 105px;
 	padding-top: 15px;
 }
 

--- a/src/components/records/BroadcastVideoRecord.vue
+++ b/src/components/records/BroadcastVideoRecord.vue
@@ -20,8 +20,8 @@
 				<div class="back-link">
 					<div class="triangle"></div>
 					<router-link
-						v-if="lastPath"
-						:to="lastPath"
+						v-if="backLink !== '/'"
+						:to="backLink"
 						class="link-container return"
 						:data-testid="addTestDataEnrichment('link', 'broadcast-video', 'back-link', 0)"
 					>
@@ -117,12 +117,11 @@
 <script lang="ts">
 import { BroadcastRecordType } from '@/types/BroadcastRecordType';
 import { GenericSearchResultType } from '@/types/GenericSearchResultTypes';
-import { defineComponent, onMounted, PropType, ref, watch } from 'vue';
+import { defineComponent, PropType, ref, watch } from 'vue';
 import VideoPlayer from '@/components/viewers/AudioVideo/VideoPlayer.vue';
 import Duration from '@/components/common/Duration.vue';
 import { copyTextToClipboard } from '@/utils/copy-script';
 import { getBroadcastDate, getBroadcastTime, getTimeFromISOFormat } from '@/utils/time-utils';
-import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { getEntryId } from '@/utils/record-utils';
 import '@/components/common/wc-spot-item';
@@ -151,18 +150,18 @@ export default defineComponent({
 				return [];
 			},
 		},
+		backLink: {
+			type: String as PropType<string>,
+			required: true,
+		},
 	},
 
 	setup(props) {
 		const lastPath = ref('');
-		const router = useRouter();
 		const { locale, t } = useI18n();
 		const searchResultStore = useSearchResultStore();
 		const entryId = ref('');
 		entryId.value = getEntryId(props.recordData);
-		onMounted(() => {
-			lastPath.value = router.options.history.state.back as string;
-		});
 
 		const emptySearchResults = () => {
 			searchResultStore.searchResult = [];
@@ -211,7 +210,7 @@ temporary styling until patterns from design system are implemented
 }
 
 .back-link {
-	width: 100%;
+	width: fit-content;
 }
 
 .back-link a {
@@ -397,7 +396,6 @@ temporary styling until patterns from design system are implemented
 	display: flex;
 	flex-direction: row;
 	bottom: 0;
-	width: 105px;
 	padding-top: 15px;
 }
 

--- a/src/components/records/NotAllowedRecord.vue
+++ b/src/components/records/NotAllowedRecord.vue
@@ -30,12 +30,12 @@
 		</div>
 		<div class="back-link">
 			<router-link
-				v-if="lastPath"
-				:to="lastPath"
+				v-if="backLink !== '/'"
+				:to="backLink"
 				:data-testid="addTestDataEnrichment('link', 'broadcast-video', 'back-link', 0)"
 			>
 				<span class="material-icons offset">chevron_left</span>
-				Tilbage
+				{{ $t('record.back') }}
 			</router-link>
 			<router-link
 				v-else
@@ -43,7 +43,7 @@
 				:data-testid="addTestDataEnrichment('link', 'broadcast-video', 'frontpage-link', 0)"
 			>
 				<span class="material-icons offset">chevron_left</span>
-				Til forsiden
+				{{ $t('record.toFrontpage') }}
 			</router-link>
 		</div>
 		<div class="extra-record-data"></div>
@@ -51,30 +51,29 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from 'vue';
+import { defineComponent, ref, PropType } from 'vue';
 import VideoPlayer from '@/components/viewers/AudioVideo/VideoPlayer.vue';
 import { copyTextToClipboard } from '@/utils/copy-script';
 import { getBroadcastDate, getBroadcastTime, getTimeFromISOFormat } from '@/utils/time-utils';
-import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import '@/components/common/wc-spot-item';
 import { addTestDataEnrichment } from '@/utils/test-enrichments';
 
 export default defineComponent({
 	name: 'NotAllowedRecord',
-
 	components: {
 		VideoPlayer,
+	},
+	props: {
+		backLink: {
+			type: String as PropType<string>,
+			required: true,
+		},
 	},
 
 	setup() {
 		const lastPath = ref('');
-		const router = useRouter();
 		const { locale, t } = useI18n();
-
-		onMounted(() => {
-			lastPath.value = router.options.history.state.back as string;
-		});
 
 		const getCurrentUrl = () => {
 			copyTextToClipboard();
@@ -109,7 +108,7 @@ temporary styling until patterns from design system are implemented
 }
 
 .back-link {
-	width: 100%;
+	width: fit-content;
 	margin-bottom: 10px;
 }
 

--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -15,7 +15,6 @@
 								ref="timeFacetButton"
 								role="switch"
 								aria-checked="false"
-								filter-button
 								:class="timeSearchStore.timeFacetsOpen ? 'time-facet-button open' : 'time-facet-button closed'"
 								@click="timeSearchStore.setTimeFacetsOpen(!timeSearchStore.timeFacetsOpen)"
 							>
@@ -84,7 +83,7 @@
 													:time-search-active="timeSearchStore.timeFacetsOpen"
 													:number="index"
 													:checked="channelFilterExists('genre', singleFacet.title, searchResultStore.categoryFilters)"
-													:loading="searchResultStore.loading"
+													:loading="searchResultStore.loadingGenres"
 													:update="updateCheckbox"
 													:parent-array="genreArray"
 												/>
@@ -131,7 +130,7 @@
 														searchResultStore.channelFilters,
 													)
 												"
-												:loading="searchResultStore.loading"
+												:loading="searchResultStore.loadingChannels"
 											/>
 										</div>
 									</TransitionGroup>

--- a/src/components/viewers/AudioVideo/VideoPlayer.vue
+++ b/src/components/viewers/AudioVideo/VideoPlayer.vue
@@ -127,8 +127,8 @@ export default defineComponent({
 						errorManager.submitCustomError(
 							'player-error',
 							t('error.title'),
-							`${t('error.record.notAllowed')} \n \n ${t('error.record.notAllowed')}`,
-							Severity.ERROR,
+							`${t('error.record.restricted')}\n\n${t('error.record.restrictedExplained')}`,
+							Severity.INFO,
 							true,
 							Priority.MEDIUM,
 						);

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -189,7 +189,7 @@
      "noBroadcastData":"Ingen sendetid",
      "seeMaterial":"See material",
     "toFrontpage": "Til forsiden",
-    "back": "Tilbage",
+    "back": "Tilbage til søgning",
     "aired": "Sendt",
      "timestamp":"kl. ",
      "title":"Titel",
@@ -342,7 +342,9 @@
     "record": {
       "loadingFailed": "Materialet kunne ikke hentes",
       "notAllowed":"Du har ikke adgang til materialet",
-      "unknown": "Ukendt"
+      "unknown": "Ukendt",
+      "restricted":"DU HAR DESVÆRRE IKKE ADGANG TIL DENNE UDSENDELSE",
+      "restrictedExplained":"Det kan skyldes at udsendelsen er underlagt ophavsret eller er klausuleret, for eksempel på grund af særligt sårbare medvirkende."
     },
     "players":{
       "video": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -191,7 +191,7 @@
      "noBroadcastData":"No air date",
      "seeMaterial":"Se materiale",
      "toFrontpage": "To the frontpage",
-     "back": "Back",
+     "back": "Back to search",
      "aired": "Aired",
      "timestamp": "at ",
      "title":"Title",
@@ -345,7 +345,9 @@
       "record": {
          "loadingFailed": "The requested material could not be loaded",
          "notAllowed":"You are not authorized to view this material",
-         "unknown": "Unknown"
+         "unknown": "Unknown",
+         "restricted":"SORRY, YOU DO NOT HAVE ACCESS TO THIS PROGRAMME",
+         "restrictedExplained":"This may be because the programme is subject to copyright or is restricted, for example due to particularly vulnerable contributors."
        },
        "players":{
             "video": {

--- a/src/store/searchResultStore.ts
+++ b/src/store/searchResultStore.ts
@@ -66,7 +66,6 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 	const toggleShowFacets = (value: boolean) => {
 		showFacets.value = value;
 		if (value) {
-			console.log('getting facets');
 			getFacetResults(lastSearchQuery.value);
 		}
 	};

--- a/src/store/timeSearchStore.ts
+++ b/src/store/timeSearchStore.ts
@@ -72,6 +72,10 @@ export const useTimeSearchStore = defineStore('timeSearchStore', () => {
 	};
 
 	const setFiltersFromUrl = (URLFilters: string[] | LocationQueryValue[] | string) => {
+		resetAllSelectorValues(days.value);
+		resetAllSelectorValues(months.value);
+		resetAllSelectorValues(timeslots.value);
+
 		const filters = normalizeFq(URLFilters as string[]);
 		if (filters !== undefined) {
 			if (filters instanceof Array) {
@@ -87,20 +91,14 @@ export const useTimeSearchStore = defineStore('timeSearchStore', () => {
 						if (filter.includes('temporal_start_day_da')) {
 							const splitDays = decodeURIComponent(filter).split(':')[1].replace(/[()]/g, '').split(' OR ');
 							setTimeFilter(days.value, splitDays);
-						} else {
-							resetAllSelectorValues(days.value);
 						}
 						if (filter.includes('temporal_start_month')) {
 							const splitMonths = decodeURIComponent(filter).split(':')[1].replace(/[()]/g, '').split(' OR ');
 							setTimeFilter(months.value, splitMonths);
-						} else {
-							resetAllSelectorValues(months.value);
 						}
 						if (filter.includes('temporal_start_hour_da')) {
 							const splitTimes = decodeURIComponent(filter).split(':')[1].replace(/[()]/g, '').split(' OR ');
 							setTimeFilter(timeslots.value, splitTimes);
-						} else {
-							resetAllSelectorValues(timeslots.value);
 						}
 					}
 				});

--- a/src/views/ShowRecord.vue
+++ b/src/views/ShowRecord.vue
@@ -7,12 +7,14 @@
 				<div v-if="!loading && recordData !== null">
 					<div v-if="recordType === 'VideoObject' || recordType === 'MediaObject'">
 						<BroadcastVideoRecordMetadataView
+							:back-link="backLink"
 							:more-like-this-records="moreLikeThisRecords"
 							:record-data="recordData as BroadcastRecordType"
 						/>
 					</div>
 					<div v-if="recordType === 'AudioObject'">
 						<BroadcastAudioRecordMetadataView
+							:back-link="backLink"
 							:more-like-this-records="moreLikeThisRecords"
 							:record-data="recordData as BroadcastRecordType"
 						/>
@@ -30,7 +32,7 @@
 					</div>
 				</div>
 				<div v-if="!loading && recordData === null && contentNotAllowed">
-					<NotAllowedRecord />
+					<NotAllowedRecord :back-link="backLink" />
 				</div>
 			</div>
 		</div>
@@ -39,7 +41,7 @@
 
 <script lang="ts">
 import { defineComponent, inject, onMounted, ref, watch } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { APIService } from '@/api/api-service';
 import GenericRecordMetadataView from '@/components/records/GenericRecord.vue';
 import GenericRecord from '@/components/records/GenericRecord.vue';
@@ -74,8 +76,34 @@ export default defineComponent({
 		const spinnerStore = useSpinnerStore();
 		const authStore = useAuthStore();
 		const route = useRoute();
+		const router = useRouter();
 		const loading = ref(true);
 		const contentNotAllowed = ref(false);
+		const backLink = ref('');
+
+		onMounted(async () => {
+			let back = router.options.history.state.back as string;
+			console.log(back);
+			if (back && back.substring(0, 5) === '/find') {
+				backLink.value = router.options.history.state.back as string;
+			} else {
+				backLink.value = '/';
+			}
+			window.scrollTo({ top: 0, behavior: 'smooth' });
+
+			if (authStore.firstAuthDone) {
+				buildContentFromReponse();
+			} else {
+				watch(
+					() => authStore.firstAuthDone,
+					(newVal: boolean) => {
+						if (newVal) {
+							buildContentFromReponse();
+						}
+					},
+				);
+			}
+		});
 
 		const getRecord = async (id: string) => {
 			spinnerStore.toggleSpinner(true);
@@ -180,24 +208,8 @@ export default defineComponent({
 				});
 			},
 		);
-		onMounted(async () => {
-			window.scrollTo({ top: 0, behavior: 'smooth' });
 
-			if (authStore.firstAuthDone) {
-				buildContentFromReponse();
-			} else {
-				watch(
-					() => authStore.firstAuthDone,
-					(newVal: boolean) => {
-						if (newVal) {
-							buildContentFromReponse();
-						}
-					},
-				);
-			}
-		});
-
-		return { recordData, recordType, moreLikeThisRecords, loading, contentNotAllowed };
+		return { recordData, recordType, moreLikeThisRecords, loading, contentNotAllowed, backLink };
 	},
 	computed: {
 		GenericRecord() {

--- a/src/views/ShowRecord.vue
+++ b/src/views/ShowRecord.vue
@@ -83,7 +83,6 @@ export default defineComponent({
 
 		onMounted(async () => {
 			let back = router.options.history.state.back as string;
-			console.log(back);
 			if (back && back.substring(0, 5) === '/find') {
 				backLink.value = router.options.history.state.back as string;
 			} else {


### PR DESCRIPTION
- Facets are now called separately. If facets are opened when we do a new search, they're called, otherwise first when the "show filters" are opened. This gives a little loadtime, but it's fine.
- Back button now goes to the last search, wherever you might have gone, or back to the frontpage if there was no search.
- Videoplayer new respons to the 1002 error from Kaltura, throwing an error and telling the user they cant access this recording.
- Fixed a bug with filters not being applied right in the timeSearchStore.
- Fixed a few background accessibility issues.
- Removed a few console.logs