### PR TITLE
Bugfix - category and genre selected in headline not getting loaded on a refresh on searchpage

### DIFF
--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -222,6 +222,8 @@ export default defineComponent({
 						genreArray.value = extendFacetPairToSelectorData(
 							simplifyFacets(searchResultStore.initFacets.facet_fields.genre),
 						);
+						setCategoryArrayFromStore(searchResultStore.categoryFilters);
+						setChannelArrayFromStore(searchResultStore.channelFilters);
 					}
 				},
 			);


### PR DESCRIPTION
This fixes it.