### PR TITLE
DRA-1532: removed the title and closed the categories container.

### DIFF
--- a/src/components/common/MainCategories.vue
+++ b/src/components/common/MainCategories.vue
@@ -1,11 +1,12 @@
 <template>
-	<!-- 	<div
+	<div
+		v-if="showHeader"
 		class="header"
 		:style="`color: ${text}`"
 	>
 		<h1>{{ title }}</h1>
 		<span>{{ subtitle }}</span>
-	</div> -->
+	</div>
 	<div class="head-categories">
 		<!-- 		<Transition
 			mode="out-in"
@@ -79,6 +80,7 @@ export default defineComponent({
 		title: { type: String, default: '' },
 		subtitle: { type: String, default: '' },
 		text: { type: String, default: 'black' },
+		showHeader: { type: Boolean, default: false },
 	},
 	setup() {
 		const { t } = useI18n();
@@ -150,7 +152,7 @@ export default defineComponent({
 	text-align: left;
 	max-width: 1280px;
 	width: 100%;
-	display: none;
+	display: block;
 	padding-right: 12px;
 	padding-left: 12px;
 	box-sizing: border-box;

--- a/src/components/common/MainCategories.vue
+++ b/src/components/common/MainCategories.vue
@@ -1,65 +1,65 @@
 <template>
-	<div
+	<!-- 	<div
 		class="header"
 		:style="`color: ${text}`"
 	>
 		<h1>{{ title }}</h1>
 		<span>{{ subtitle }}</span>
-	</div>
+	</div> -->
 	<div class="head-categories">
-		<Transition
+		<!-- 		<Transition
 			mode="out-in"
 			name="fade"
+		> -->
+		<div v-if="categoriesLoaded && categories.length > 0">
+			<div class="container category-grid">
+				<router-link
+					v-for="(entity, i) in categories"
+					:key="i"
+					:to="{
+						name: 'Search',
+						query: {
+							q: '*:*',
+							start: 0,
+							fq: [encodeURIComponent(`genre:${quotation(entity.name)}`)],
+						},
+					}"
+					class="category-item"
+					:data-testid="addTestDataEnrichment('link', 'category-item', `catergory-${entity.name}`, i)"
+					@click="scrollToTop()"
+				>
+					{{ t(`categories.${santizeAndSimplify(entity.name)}`) }}
+					<span class="number">{{ entity.number.toLocaleString('de-DE') }}</span>
+					<span :class="`category-image ${santizeAndSimplify(entity.name)}`"></span>
+				</router-link>
+			</div>
+		</div>
+		<div
+			v-else
+			class="container"
 		>
-			<div v-if="categoriesLoaded && categories.length > 0">
-				<div class="container category-grid">
-					<router-link
-						v-for="(entity, i) in categories"
-						@click="scrollToTop()"
-						:key="i"
-						:to="{
-							name: 'Search',
-							query: {
-								q: '*:*',
-								start: 0,
-								fq: [encodeURIComponent(`genre:${quotation(entity.name)}`)],
-							},
-						}"
-						class="category-item"
-						:data-testid="addTestDataEnrichment('link', 'category-item', `catergory-${entity.name}`, i)"
-					>
-						{{ t(`categories.${santizeAndSimplify(entity.name)}`) }}
-						<span class="number">{{ entity.number.toLocaleString('de-DE') }}</span>
-						<span :class="`category-image ${santizeAndSimplify(entity.name)}`"></span>
-					</router-link>
+			<div class="container category-grid">
+				<div
+					v-for="i in 12"
+					:key="i"
+					class="category-item"
+				>
+					<span
+						:style="`width:${Math.random() * 30 + 30}%`"
+						class="loading"
+					></span>
+					<span
+						:style="`width:${Math.random() * 3 + 3}%`"
+						class="loading number"
+					></span>
+					<NoFacetContent
+						v-if="categoriesLoaded && categories.length === 0"
+						position="absolute"
+					></NoFacetContent>
 				</div>
 			</div>
-			<div
-				v-else
-				class="container"
-			>
-				<div class="container category-grid">
-					<div
-						v-for="i in 12"
-						:key="i"
-						class="category-item"
-					>
-						<span
-							:style="`width:${Math.random() * 30 + 30}%`"
-							class="loading"
-						></span>
-						<span
-							:style="`width:${Math.random() * 3 + 3}%`"
-							class="loading number"
-						></span>
-						<NoFacetContent
-							v-if="categoriesLoaded && categories.length === 0"
-							position="absolute"
-						></NoFacetContent>
-					</div>
-				</div>
-			</div>
-		</Transition>
+		</div>
+		<!-- 		</Transition> -->
 	</div>
 </template>
 <script lang="ts">

--- a/src/components/common/PortalContent.vue
+++ b/src/components/common/PortalContent.vue
@@ -10,6 +10,7 @@
 				:fullwidth="true"
 				:shadow-bottom="true"
 				:shadow-top="true"
+				:always-expand="true"
 				:subtitle="$t('timeSearch.searchCategoriesSubtitle')"
 			>
 				<MainCategories

--- a/src/components/common/PortalContent.vue
+++ b/src/components/common/PortalContent.vue
@@ -12,6 +12,7 @@
 				:shadow-top="true"
 				:always-expand="true"
 				:subtitle="$t('timeSearch.searchCategoriesSubtitle')"
+				:hover-effect="true"
 			>
 				<MainCategories
 					:title="$t('timeSearch.searchCategories')"

--- a/src/components/common/SkewedFoldable.vue
+++ b/src/components/common/SkewedFoldable.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		ref="foldableRef"
-		class="foldable-container"
+		:class="foldableOpen ? 'foldable-container open' : 'foldable-container closed'"
 		@click="toggleContent($event, false)"
 	>
 		<div
@@ -270,16 +270,6 @@ h1::first-letter {
 	max-width: 720px;
 }
 
-.foldable-container:hover .edge.hover,
-.foldable-container:hover .content.hover {
-	background-color: #c4f1ed !important;
-}
-
-.edge.hover,
-.content.hover {
-	transition: background-color 0.15s linear 0s;
-}
-
 .content .headline h1 {
 	padding: 0px;
 	margin: 0px;
@@ -437,6 +427,27 @@ h1::first-letter {
 	transform: scaleY(1);
 }
 @media (min-width: 990px) {
+	.hover .headline,
+	.hover .material-icons {
+		transition: all 0.15s linear 0s;
+	}
+
+	.closed .hover:hover .headline,
+	.closed .hover:hover .material-icons {
+		color: #0a2e70 !important;
+	}
+
+	.closed:hover .edge.hover,
+	.closed:hover .content.hover {
+		background-color: #c4f1ed !important;
+		color: #0a2e70 !important;
+	}
+
+	.closed .edge.hover,
+	.closed .content.hover {
+		transition: all 0.15s linear 0s;
+	}
+
 	.foldable-toggle {
 		display: none;
 	}

--- a/src/components/search/NoHits.vue
+++ b/src/components/search/NoHits.vue
@@ -84,6 +84,7 @@
 							:title="$t('timeSearch.searchCategories')"
 							text="white"
 							:subtitle="$t('timeSearch.searchCategoriesSubtitle')"
+							:show-header="true"
 						></MainCategories>
 					</div>
 				</template>


### PR DESCRIPTION
On the frontpage, the categorys are now closed, and can be folded out, in all the layouts (before, it was open at the desktop breakpoint and forward.)
On the nohits page, the categorys are still folded out on all layouts, and the description is added. (because it's nice that way)