### PR TITLE
DRA-1444: Handling no record ID on record page.

### DIFF
--- a/src/components/common/MainCategories.vue
+++ b/src/components/common/MainCategories.vue
@@ -201,6 +201,7 @@ export default defineComponent({
 	justify-content: center;
 	min-height: 200px;
 	box-sizing: border-box;
+	padding: 0px 12px;
 }
 
 .category-item {

--- a/src/components/global/content-elements/EdgedContentArea.vue
+++ b/src/components/global/content-elements/EdgedContentArea.vue
@@ -154,7 +154,6 @@ temporary styling until patterns from design system are implemented
 }
 
 .full-width {
-	width: calc(100% + 24px);
 	min-height: 200px;
 	z-index: 5;
 	position: relative;

--- a/src/components/records/UnavailableRecord.vue
+++ b/src/components/records/UnavailableRecord.vue
@@ -39,7 +39,7 @@
 			</template>
 		</EdgedContentArea>
 		<div class="contactus">
-			<ContactUs />
+			<ContactUs :relative-position="false" />
 		</div>
 	</div>
 </template>
@@ -71,11 +71,6 @@ export default defineComponent({
 	flex-direction: column;
 	width: 100%;
 	padding-bottom: 25px;
-}
-
-.contactus {
-	margin-top: 60px;
-	margin-bottom: 0px;
 }
 
 .btn {
@@ -130,30 +125,9 @@ export default defineComponent({
 	border-color: #002e70;
 }
 
-@media (min-width: 480px) {
-	.contactus {
-		margin-bottom: -20px;
-	}
-}
-
-@media (min-width: 640px) {
-	.contactus {
-		margin-top: 80px;
-		margin-bottom: -80px;
-	}
-}
-
-@media (min-width: 990px) {
-	.contactus {
-		margin-bottom: -120px;
-		margin-top: 105px;
-	}
-}
-
 @media (min-width: 1200px) {
 	.contactus {
-		margin-bottom: -130px;
-		margin-top: 130px;
+		margin-bottom: -6vh;
 	}
 }
 </style>

--- a/src/components/records/UnavailableRecord.vue
+++ b/src/components/records/UnavailableRecord.vue
@@ -1,0 +1,122 @@
+<template>
+	<div class="unavailable-record">
+		<div class="not-found-details">
+			<h2>{{ t('record.noRecordFound') }}</h2>
+			<p>{{ t('record.noRecordFoundExplained') }}</p>
+			<h2>{{ t('error.wrongUrl.altHeader') }}</h2>
+			<div class="extra-suggest">
+				<a
+					class="btn-blue btn"
+					href="/find-materiale/dr-arkivet/"
+					:data-testid="addTestDataEnrichment('button', 'unavailable-record', 'link-to-home', 0)"
+				>
+					{{ t('error.wrongUrl.frontPage') }}
+				</a>
+				<a
+					class="btn-blue btn"
+					:href="t('footer.column1.links.1.link')"
+					:data-testid="addTestDataEnrichment('button', 'unavailable-record', 'link-to-about', 0)"
+				>
+					{{ t('footer.column1.links.1.title') }}
+				</a>
+				<a
+					class="btn-blue btn"
+					href="https://www.kb.dk"
+					:data-testid="addTestDataEnrichment('button', 'unavailable-record', 'link-to-kb', 0)"
+				>
+					{{ t('error.wrongUrl.kbPage') }}
+				</a>
+			</div>
+		</div>
+		<EdgedContentArea
+			:lines="true"
+			:line-padding="false"
+			background-color="#002e70"
+			:title="t('search.mainCategories')"
+		>
+			<template #content>
+				<MainCategories />
+			</template>
+		</EdgedContentArea>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { addTestDataEnrichment } from '@/utils/test-enrichments';
+import MainCategories from '@/components/common/MainCategories.vue';
+import EdgedContentArea from '@/components/global/content-elements/EdgedContentArea.vue';
+
+export default defineComponent({
+	name: 'GenericRecord',
+	components: {
+		MainCategories,
+		EdgedContentArea,
+	},
+	setup() {
+		const { t } = useI18n();
+		return { t, addTestDataEnrichment };
+	},
+});
+</script>
+<style scoped>
+.not-found-details {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	padding-bottom: 25px;
+}
+
+.btn {
+	display: inline-block;
+	font-weight: 400;
+	color: #171717;
+	text-align: center;
+	text-decoration: none;
+	vertical-align: middle;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	background-color: transparent;
+	border: 1px solid transparent;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-bottom-color: transparent;
+	border-left-color: transparent;
+	padding: 13px 2.875rem;
+	font-size: 1rem;
+	line-height: 1.25rem;
+	border-radius: 0.25rem;
+	transition:
+		color 0.15s ease-in-out,
+		background-color 0.15s ease-in-out,
+		border-color 0.15s ease-in-out,
+		box-shadow 0.15s ease-in-out;
+	margin-right: 15px;
+	margin-bottom: 15px;
+	white-space: nowrap;
+}
+.btn-light {
+	color: #212529;
+	background-color: #f2f4f8;
+	border-color: #f2f4f8;
+}
+.btn-blue {
+	color: white;
+	background-color: #002e70;
+	border-color: #f2f4f8;
+}
+.btn-light:hover {
+	color: #212529;
+	background-color: #d9dfeb;
+	border-color: #d1d8e6;
+}
+
+.btn-blue:hover {
+	background-color: #c4f1ed;
+	color: #002e70;
+	border-color: #002e70;
+}
+</style>

--- a/src/components/records/UnavailableRecord.vue
+++ b/src/components/records/UnavailableRecord.vue
@@ -74,7 +74,8 @@ export default defineComponent({
 }
 
 .contactus {
-	margin-top: 150px;
+	margin-top: 60px;
+	margin-bottom: 0px;
 }
 
 .btn {
@@ -128,9 +129,31 @@ export default defineComponent({
 	color: #002e70;
 	border-color: #002e70;
 }
+
+@media (min-width: 480px) {
+	.contactus {
+		margin-bottom: -20px;
+	}
+}
+
+@media (min-width: 640px) {
+	.contactus {
+		margin-top: 80px;
+		margin-bottom: -80px;
+	}
+}
+
 @media (min-width: 990px) {
 	.contactus {
-		margin-bottom: -150px;
+		margin-bottom: -120px;
+		margin-top: 105px;
+	}
+}
+
+@media (min-width: 1200px) {
+	.contactus {
+		margin-bottom: -130px;
+		margin-top: 130px;
 	}
 }
 </style>

--- a/src/components/records/UnavailableRecord.vue
+++ b/src/components/records/UnavailableRecord.vue
@@ -38,6 +38,9 @@
 				<MainCategories />
 			</template>
 		</EdgedContentArea>
+		<div class="contactus">
+			<ContactUs />
+		</div>
 	</div>
 </template>
 
@@ -47,12 +50,14 @@ import { useI18n } from 'vue-i18n';
 import { addTestDataEnrichment } from '@/utils/test-enrichments';
 import MainCategories from '@/components/common/MainCategories.vue';
 import EdgedContentArea from '@/components/global/content-elements/EdgedContentArea.vue';
+import ContactUs from '../search/ContactUs.vue';
 
 export default defineComponent({
 	name: 'GenericRecord',
 	components: {
 		MainCategories,
 		EdgedContentArea,
+		ContactUs,
 	},
 	setup() {
 		const { t } = useI18n();
@@ -66,6 +71,10 @@ export default defineComponent({
 	flex-direction: column;
 	width: 100%;
 	padding-bottom: 25px;
+}
+
+.contactus {
+	margin-top: 150px;
 }
 
 .btn {
@@ -118,5 +127,10 @@ export default defineComponent({
 	background-color: #c4f1ed;
 	color: #002e70;
 	border-color: #002e70;
+}
+@media (min-width: 990px) {
+	.contactus {
+		margin-bottom: -150px;
+	}
 }
 </style>

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -2,6 +2,7 @@
    "app": {
       "skip":"Spring til hovedindhold",
       "titles": {
+         "unknown":"Ukendt udsendelse",
          "frontpage": {
             "archive":  {
                "name": "DR-arkiv",

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -215,8 +215,9 @@
      "copyTitleFailed":"Kopiering fejlede.",
      "copyMessageFailed":"Linket blev ikke kopieret. Kopier URL i stedet.",
      "moreMetadataBroadcast":"Yderligere information om udsendelsen",
-     "missingStreamingUrl":"Vi beklager, men denne post har ingen steaming URL, \n så der er intet at vise."
-
+     "missingStreamingUrl":"Vi beklager, men denne post har ingen steaming URL, \n så der er intet at vise.",
+     "noRecordFound":"Vi kan desværre ikke finde den udsendelse, som du forsøger at tilgå :(",
+     "noRecordFoundExplained":"Det er er super ærgeligt, og hvordan du er kommet herind er lidt en gåde, men du kan prøve at søge igen for at finde det indhold du savner."
   },
   "duration":{
    "hours":"t",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,6 +2,7 @@
    "app": {
       "skip":"Skip to main content",
       "titles": {
+         "unknown":"Unknown broadcast",
          "frontpage": {
             "archive":  {
                "name": "DR-archive",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -217,8 +217,9 @@
      "copyTitleFailed":"Copying failed.",
      "copyMessageFailed":"The link was not copied to the clipboard. Copy the URL instead.",
      "moreMetadataBroadcast":"Additional information about the broadcast",
-     "missingStreamingUrl":"We're sorry, it seems this record has no streaming URL, \n so there is nothing to show."
-
+     "missingStreamingUrl":"We're sorry, it seems this record has no streaming URL, \n so there is nothing to show.",
+     "noRecordFound":"Unfortunately, we cannot find the broadcast you are trying to access :(",
+     "noRecordFoundExplained":"It's really unfortunate, and how you ended up here is a bit of a mystery, but you can try searching again to find the content you're missing."
   },
   "duration":{
    "hours":"h",

--- a/src/views/ShowRecord.vue
+++ b/src/views/ShowRecord.vue
@@ -185,7 +185,7 @@ export default defineComponent({
 					moreLikeThisRecords.value = moreLikeThis.data.response.docs;
 				}
 			} else {
-				document.title = ('Unknown' + t('app.titles.frontpage.archive.suffix')) as string;
+				document.title = `${t('app.titles.unknown')} ${t('app.titles.frontpage.archive.suffix')}` as string;
 			}
 			if (moreLikeThisRecords.value.length === 0) {
 				const startAndEnd = getStartAndEndFromStartTime();


### PR DESCRIPTION
This should solve the problem of a manipulated record url. If you find a record and change it around to a record that doesn't exist, like http://localhost:3000/find-materiale/dr-arkivet/post/ds.tv:oai:io:fd596c49-0836-4546-b131-20ec25c6b11edsadsa - you'll now get a decent "we cant find this"-page instead of just an empty one.