### PR TITLE
DRA-1478 autocomplete pick correct element

### DIFF
--- a/src/components/search/Autocomplete.vue
+++ b/src/components/search/Autocomplete.vue
@@ -22,7 +22,7 @@
 					<button
 						:title="item?.term"
 						:data-testid="addTestDataEnrichment('button', 'autcomplete', `term-${item.term}`, i)"
-						@click="executeOnSelection"
+						@click="executeOnSelection($event, i + 1)"
 						@mouseenter="updateSelectedElement(i + 1)"
 						@mouseleave="updateSelectedElement(0)"
 					>
@@ -127,9 +127,14 @@ export default defineComponent({
 			}
 		};
 
-		const executeOnSelection = (e: Event) => {
+		const executeOnSelection = (e: PointerEvent, n: number) => {
 			if (currentSelectedAutocomplete.value !== 0) {
 				e.preventDefault();
+				// pointerType mouse is for a mouse click, where pointerType would be "" if enter
+				if (e.pointerType === 'mouse') {
+					//updated selected element to make sure it picks the clicked element.
+					updateSelectedElement(n);
+				}
 				doAutocompleteSearch(searchResultStore.autocompleteResult[currentSelectedAutocomplete.value - 1].term);
 			}
 		};


### PR DESCRIPTION
If you hover over an autocomplete element. Then use arrows or tab to select other element. 
Before if you then clicked with your mouse, it would choose the selected element from the arrows. 

This fix should make sure, if you mouse click an element, it will always choose the clicked element. 
With enter, it should pick the active element