### PR TITLE
DRA-BUGFIX No hit correct title

### DIFF
--- a/src/components/search/NoHits.vue
+++ b/src/components/search/NoHits.vue
@@ -4,7 +4,13 @@
 		mode="out-in"
 	>
 		<div>
-			<div class="no-hits-heading">{{ $t('search.nohit', { query: searchResultStore.lastSearchQuery }) }}</div>
+			<div class="no-hits-heading">
+				{{
+					searchResultStore.lastSearchQuery === '*:*'
+						? $t('search.nohitWithFilter', { filterSearch: $t('search.filterSearch') })
+						: $t('search.nohit', { query: searchResultStore.lastSearchQuery })
+				}}
+			</div>
 			<div class="no-hits-heading-subtitle">
 				<p>{{ $t('search.nohitSubtitle.firstPart') }}</p>
 				<p>{{ $t('search.nohitSubtitle.secondPart') }}</p>
@@ -190,7 +196,7 @@ export default defineComponent({
 	font-size: 36px;
 	word-wrap: break-word;
 	hyphens: auto;
-	max-width: 750px;
+	max-width: 800px;
 }
 h2 {
 	margin: 0;

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -121,6 +121,7 @@
      "tipsTitle": "Et par fif til din søgning",
      "mainCategories": "led videre i vores hovedkategorier",
      "nohit":"Vi fandt desværre ingen resultater, der matcher din søgning på \"{query}\"",
+     "nohitWithFilter":"Vi beklager ingen {filterSearch}",
      "showFilters":"Vis filtre",
      "hideFilters":"Skjul filtre",
     "resetFilters": "Nulstil filtre",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -112,6 +112,7 @@
      "hitcount": " result fund with | results found with",
      "filterSearch": " results found with your filters",
      "nohit":"Sorry, we did not find any results matching your search for \"{query}\"",
+     "nohitWithFilter":"We are sorrry no {filterSearch}",
      "nohitSubtitle": {
         "firstPart": "We are sorry that it was not possible to find a result for your search. Not all programmes in the archive are linked to good search words yet, so it may take a few tries to find what you are looking for.",
         "secondPart": "Perhaps you have searched for something that has not yet entered the archive or that we are not allowed to show in the archive.",


### PR DESCRIPTION
NoHits page displays *:* in header if a user adds filters which results in no hits. 

Header now looks after *:* in query. 
Different header text
Added more space for header, to avoid word-break