### PR TITLE
DRA-1833: empty spell suggest before new search

### DIFF
--- a/src/store/searchResultStore.ts
+++ b/src/store/searchResultStore.ts
@@ -336,6 +336,7 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 			//window.scrollTo({ top: 0, behavior: 'smooth' });
 			searchFired.value = true;
 			loading.value = true;
+			spellCheck.value = {} as unknown as SpellCheckType;
 			const responseData = await APIService.getSearchResults(
 				query,
 				searchFilters,


### PR DESCRIPTION
This ensures that if we ever get an error after an empty search, there wont be old search suggestions.