### PR TITLE
DRA-1867: Remove KalturaStartTime params on /post/:id route before entering.

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -20,14 +20,16 @@ const routes: Array<RouteRecordRaw> = [
 			autoplay: route.query.autoplay || null,
 		}),
 		beforeEnter: (to, from, next) => {
-			if ('kalturaStartTime' in to.query || 'KalturaStartTime' in to.query) {
-				const rest = { ...to.query };
-				delete rest.kalturaStartTime;
-				delete rest.KalturaStartTime;
+			const query = { ...to.query };
+			const targetKey = Object.keys(query).find((key) => key.toLowerCase() === 'kalturastarttime');
+
+			if (targetKey) {
+				delete query[targetKey];
+
 				next({
 					name: to.name,
 					params: to.params,
-					query: rest,
+					query,
 					replace: true,
 				});
 			} else {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -19,6 +19,21 @@ const routes: Array<RouteRecordRaw> = [
 			id: route.params.id,
 			autoplay: route.query.autoplay || null,
 		}),
+		beforeEnter: (to, from, next) => {
+			if ('kalturaStartTime' in to.query || 'KalturaStartTime' in to.query) {
+				const rest = { ...to.query };
+				delete rest.kalturaStartTime;
+				delete rest.KalturaStartTime;
+				next({
+					name: to.name,
+					params: to.params,
+					query: rest,
+					replace: true,
+				});
+			} else {
+				next();
+			}
+		},
 	},
 	{
 		path: '/:pathMatch(.*)*', // Catch-all route


### PR DESCRIPTION
Added a beforeEnter check to remove kalturaStartTime params on the /post/:id route to make sure we start the video from 0.

This can be checked if working on devel by entering a post, like such, with params on it:

 /dr-arkivet/post/ds.tv:oai:io:633a70f4-7d3e-4962-ac1c-97e55c5c812a?KalturaStartTime=300
 
 The route removes the params now, (in any variation of big and small letters), and starts the video at the beginning.