### PR TITLE
DRA-1882: A better /find page with no params set.

### DIFF
--- a/src/components/search/CurrentFilters.vue
+++ b/src/components/search/CurrentFilters.vue
@@ -241,11 +241,18 @@ export default defineComponent({
 				startDate.value.setTime(startYear.value.getTime());
 				endDate.value.setTime(endYear.value.getTime());
 			}
+
+			if (routeQueries.q === '*:*') {
+				delete routeQueries.q;
+			}
+
+			delete routeQueries.start;
+			delete routeQueries.fq;
+			delete routeQueries.sort;
+
 			router.push({
 				name: 'Search',
-				query: {
-					q: routeQueries.q,
-				},
+				query: routeQueries,
 			});
 		};
 

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -6,7 +6,7 @@
 					<div class="col">
 						<form
 							ref="searchFormRef"
-							:class="route.query.q === undefined ? 'searchform find' : 'searchform'"
+							:class="route.query.q === undefined && route.name === 'Search' ? 'searchform find' : 'searchform'"
 							action=" "
 							method=" "
 							role="search"

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -6,7 +6,7 @@
 					<div class="col">
 						<form
 							ref="searchFormRef"
-							class="searchform"
+							:class="route.query.q === undefined ? 'searchform find' : 'searchform'"
 							action=" "
 							method=" "
 							role="search"
@@ -214,6 +214,7 @@ import { useSearchResultStore } from '@/store/searchResultStore';
 import Autocomplete from '@/components/search/Autocomplete.vue';
 import { LocationQueryRaw } from 'vue-router';
 import router from '@/router';
+import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { addTestDataEnrichment } from '@/utils/test-enrichments';
 import gsap from 'gsap';
@@ -236,6 +237,7 @@ export default defineComponent({
 		const searchFormRef = ref<HTMLFormElement | null>(null);
 		const showPortalSelector = ref(false);
 		const selectedPortal = ref('drArchive');
+		const route = useRoute();
 		const selectButtonRef = ref<HTMLButtonElement | null>(null);
 		const selectorValues: PortalSelectItem[] = [
 			{
@@ -431,6 +433,7 @@ export default defineComponent({
 			selectButtonRef,
 			selectedPortal,
 			selectorValues,
+			route,
 		};
 	},
 });
@@ -495,6 +498,10 @@ input[type='search']::-webkit-search-results-decoration {
 	color: #767676;
 }
 
+.searchform.find .rdl-advanced-search {
+	border: 1px solid #002e70;
+}
+
 :host {
 	max-width: 100vw;
 	height: 100%;
@@ -502,7 +509,9 @@ input[type='search']::-webkit-search-results-decoration {
 }
 
 .searchform {
+	transition: all 0.25s linear 0s;
 	overflow: visible;
+	border: 1px solid transparent;
 }
 
 .search-box {
@@ -971,7 +980,7 @@ input:focus {
 	}
 
 	.dropdown-toggle {
-		height: 72px;
+		height: 71px;
 		padding: 20px 12px;
 	}
 
@@ -1053,7 +1062,7 @@ input:focus {
 	}
 	.form-control {
 		padding: 20px 12px;
-		height: 72px;
+		height: 71px;
 		border: none;
 		display: block;
 		width: 100%;

--- a/src/components/search/SearchOverhead.vue
+++ b/src/components/search/SearchOverhead.vue
@@ -259,11 +259,17 @@ export default defineComponent({
 				startDate.value.setTime(startYear.value.getTime());
 				endDate.value.setTime(endYear.value.getTime());
 			}
+
+			if (routeQueries.q === '*:*') {
+				delete routeQueries.q;
+			}
+			delete routeQueries.start;
+			delete routeQueries.fq;
+			delete routeQueries.sort;
+
 			router.push({
 				name: 'Search',
-				query: {
-					q: routeQueries.q,
-				},
+				query: routeQueries,
 			});
 		};
 

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -525,5 +525,12 @@
       "nyheder-politik-og-samfund":"Nyheder, politik og samfund",
       "radio-rodekasse":"Radio-rodekasse",
       "tv-rodekasse":"TV-rodekasse"
+   },
+   "find":{
+      "headline":"Hvad vil du søge efter?",
+      "subtitle":"Skriv i søgefeltet eller vælg en kategori for at begynde din søgning.",
+      "maybeYouWantTo":"Eller måske vil du hellere:",
+      "restoreFilters":"Gendanne filtre fra sidste søgning",
+      "GoToFrontpage":"Til forsiden af DR-arkivet"
    }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -531,5 +531,12 @@
       "nyheder-politik-og-samfund":"News, politics, and society",
       "radio-rodekasse":"Radio jumble box",
       "tv-rodekasse":"TV jumble box"
-   } 
+   },
+   "find":{
+      "headline":"What do you want to search for?",
+      "subtitle":"Use the search field or select a category to begin your search.",
+      "maybeYouWantTo":"Or maybe you would rather:",
+      "restoreFilters":"Restore filters from previous search",
+      "GoToFrontpage":"Go to the front page of DR-arkivet"
+   }
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
+import { useSearchResultStore } from '@/store/searchResultStore';
 
 const routes: Array<RouteRecordRaw> = [
 	{
@@ -50,6 +51,8 @@ const router = createRouter({
 });
 
 router.beforeEach((to, from) => {
+	const searchResultStore = useSearchResultStore();
+	searchResultStore.previousRoute = from;
 	if (from.query.locale && !to.query.locale) {
 		to.query.locale = from.query.locale;
 		return to;

--- a/src/store/searchResultStore.ts
+++ b/src/store/searchResultStore.ts
@@ -6,7 +6,7 @@ import { AxiosError } from 'axios';
 import { computed, inject, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { SpellCheckType } from '@/types/SpellCheckType';
-import { LocationQueryValue } from 'vue-router';
+import { LocationQueryValue, RouteLocationNormalizedLoadedGeneric } from 'vue-router';
 import { APIAutocompleteTerm } from '@/types/APIResponseTypes';
 import { Priority, Severity } from '@/types/NotificationType';
 import { CuratedItemsType } from '@/types/CuratedItemsType';
@@ -48,6 +48,7 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 	const loadingChannels = ref(false);
 	const loadingGenres = ref(false);
 	const totalPages = computed(() => Math.ceil(numFound.value / Number(rowCount.value)));
+	const previousRoute = ref({} as RouteLocationNormalizedLoadedGeneric);
 	//We normally display 10 or 40 items per page. This'll make it dynamic
 	const maxPages = computed(() =>
 		totalPages.value > 1000 / Number(rowCount.value) ? 1000 / Number(rowCount.value) : totalPages.value,
@@ -403,6 +404,7 @@ export const useSearchResultStore = defineStore('searchResults', () => {
 		loadingGenres,
 		loadingChannels,
 		curatedContent,
+		previousRoute,
 		addFilter,
 		resetFilters,
 		removeFilter,

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -59,7 +59,10 @@
 					<p>{{ t('find.subtitle') }}</p>
 					<h2>{{ t('find.maybeYouWantTo') }}</h2>
 					<div class="extra-options">
-						<router-link :to="searchResultStore.previousRoute">{{ t('find.restoreFilters') }}</router-link>
+						<router-link :to="searchResultStore.previousRoute">
+							<span class="material-icons tune">tune</span>
+							{{ t('find.restoreFilters') }}
+						</router-link>
 						<router-link :to="{ name: 'Home' }">{{ t('find.GoToFrontpage') }}</router-link>
 					</div>
 					<EdgedContentArea
@@ -417,6 +420,10 @@ h3 {
 
 .expanded-area {
 	height: 3vw;
+}
+
+.tune {
+	padding-right: 5px;
 }
 
 .extra-options {

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -429,6 +429,8 @@ h3 {
 .extra-options {
 	display: flex;
 	gap: 25px;
+	flex-direction: column;
+	margin-bottom: 45px;
 }
 
 .extra-options a {
@@ -482,6 +484,9 @@ h3 {
 }
 /* MEDIA QUERY 640 */
 @media (min-width: 640px) {
+	.extra-options {
+		flex-direction: row;
+	}
 	.container {
 		max-width: 990px;
 	}
@@ -496,6 +501,9 @@ h3 {
 @media (min-width: 990px) {
 	.mobile-edge {
 		display: none;
+	}
+	.extra-options {
+		margin-bottom: 0px;
 	}
 	.container {
 		display: flex;

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -51,9 +51,42 @@
 						</div>
 					</div>
 				</div>
-
 				<div
-					v-if="route.fullPath === '/find'"
+					v-if="route.query.q === undefined"
+					class="container find"
+				>
+					<h1>{{ t('find.headline') }}</h1>
+					<p>{{ t('find.subtitle') }}</p>
+					<h2>{{ t('find.maybeYouWantTo') }}</h2>
+					<div class="extra-options">
+						<router-link :to="searchResultStore.previousRoute">{{ t('find.restoreFilters') }}</router-link>
+						<router-link to="Home">{{ t('find.GoToFrontpage') }}</router-link>
+					</div>
+					<EdgedContentArea
+						:lines="true"
+						:title="$t('search.mainCategories')"
+						class="main-categories-header"
+						:reverse="true"
+					>
+						<template #content>
+							<div class="showcase-container">
+								<MainCategories
+									:title="$t('timeSearch.searchCategories')"
+									text="white"
+									:subtitle="$t('timeSearch.searchCategoriesSubtitle')"
+									:show-header="false"
+								></MainCategories>
+							</div>
+						</template>
+					</EdgedContentArea>
+					<ContactUs
+						class="contact-us"
+						:relative-position="false"
+					></ContactUs>
+					<div class="expanded-area"></div>
+				</div>
+				<div
+					v-if="route.fullPath === '/find' && route.query.q !== undefined"
 					key="2"
 					class="container"
 				>
@@ -82,6 +115,9 @@ import { ErrorManagerType } from '@/types/ErrorManagerType';
 import NoHits from '@/components/search/NoHits.vue';
 import { Priority, Severity } from '@/types/NotificationType';
 import { normalizeFq } from '@/utils/filter-utils';
+import EdgedContentArea from '@/components/global/content-elements/EdgedContentArea.vue';
+import MainCategories from '@/components/common/MainCategories.vue';
+import ContactUs from '@/components/search/ContactUs.vue';
 
 export default defineComponent({
 	name: 'Search',
@@ -90,6 +126,9 @@ export default defineComponent({
 		Pagination,
 		SearchOverhead,
 		NoHits,
+		EdgedContentArea,
+		MainCategories,
+		ContactUs,
 	},
 
 	setup() {
@@ -302,6 +341,8 @@ export default defineComponent({
 			numPagesToShow,
 			route,
 			updateResizeProperty,
+			router,
+			t,
 		};
 	},
 });
@@ -372,6 +413,48 @@ h3 {
 .search-resultset {
 	display: flex;
 	flex-direction: column;
+}
+
+.expanded-area {
+	height: 3vw;
+}
+
+.extra-options {
+	display: flex;
+	gap: 25px;
+}
+
+.extra-options a {
+	color: white;
+	background-color: #002e70;
+	border-color: #f2f4f8;
+	text-decoration: none;
+	padding: 1px 2rem;
+	line-height: 1.25rem;
+	border-radius: 5px;
+	height: 45px;
+	display: flex;
+	align-items: center;
+	transition:
+		color 0.15s ease-in-out,
+		background-color 0.15s ease-in-out,
+		border-color 0.15s ease-in-out,
+		box-shadow 0.15s ease-in-out;
+}
+
+.extra-options a:hover {
+	background-color: #c4f1ed;
+	color: #002e70;
+	border-color: #002e70;
+	outline: 1px solid #002e70;
+}
+
+.find h1 {
+	font-weight: normal;
+}
+
+.find h2 {
+	color: #002e70;
 }
 
 .container {

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -60,7 +60,7 @@
 					<h2>{{ t('find.maybeYouWantTo') }}</h2>
 					<div class="extra-options">
 						<router-link :to="searchResultStore.previousRoute">{{ t('find.restoreFilters') }}</router-link>
-						<router-link to="Home">{{ t('find.GoToFrontpage') }}</router-link>
+						<router-link :to="{ name: 'Home' }">{{ t('find.GoToFrontpage') }}</router-link>
 					</div>
 					<EdgedContentArea
 						:lines="true"


### PR DESCRIPTION
This PR is doing 2 things:

1: Making sure any reset of filters on *:* searches now also removes the query, sending you to an empty /find page.
2: Restyled the /find page after the UX-design provided by Daniel - which can be found in the JIRA ticket.