### PR TITLE
DRA-1921 limit query size

### DIFF
--- a/src/components/common/CustomTimelineCheckbox.vue
+++ b/src/components/common/CustomTimelineCheckbox.vue
@@ -5,16 +5,17 @@
 		:name="name"
 		type="checkbox"
 		:checked="val"
+		:disabled="disabled && !val"
 		:data-testid="addTestDataEnrichment('input', 'timeline-checkbox', name, index)"
 		@change="updateSelection($event)"
 	/>
 	<label
 		:title="$t(name)"
-		:class="tilted ? 'tilted' : ''"
+		:class="getClassStyle(false)"
 		:for="name + '-checkbox-' + index"
 	>
 		<span class="checkbox-title">{{ $t(name) }}</span>
-		<span :class="tilted ? 'checkbox-square tilted' : 'checkbox-square'">
+		<span :class="getClassStyle(true)">
 			<span class="checkbox-checkmark"></span>
 		</span>
 	</label>
@@ -64,11 +65,19 @@ export default defineComponent({
 				return [] as SelectorData[];
 			},
 		},
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	setup(props) {
 		const checkboxRef = ref<HTMLInputElement | null>(null);
 		const checkboxLabelRef = ref<HTMLLabelElement | null>(null);
+
+		const getClassStyle = (isCheckbox: boolean) => {
+			return { 'checkbox-square': isCheckbox, tilted: props.tilted, 'checkbox-disabled': props.disabled && !props.val };
+		};
 
 		watch(
 			() => props.val,
@@ -83,7 +92,7 @@ export default defineComponent({
 			props.update(props.parentArray, props.index, target.checked);
 		};
 
-		return { updateSelection, checkboxRef, checkboxLabelRef, addTestDataEnrichment };
+		return { updateSelection, checkboxRef, checkboxLabelRef, addTestDataEnrichment, getClassStyle };
 	},
 });
 </script>
@@ -190,5 +199,11 @@ export default defineComponent({
 	left: 10px;
 	top: -14px;
 	transform: rotateZ(-52deg) translate(-50%, -50%);
+}
+
+.checkbox-disabled {
+	cursor: default !important;
+	border-color: rgb(177, 177, 177) !important;
+	color: rgb(177, 177, 177) !important;
 }
 </style>

--- a/src/components/common/SimpleCheckbox.vue
+++ b/src/components/common/SimpleCheckbox.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :class="amount === '0' ? 'checkbox-container disabled' : 'checkbox-container'">
+	<div :class="getClassStyle()">
 		<label
 			:title="title"
 			class="label"
@@ -34,7 +34,7 @@
 				type="checkbox"
 				class="checkbox"
 				:name="title"
-				:disabled="amount === '0' && !checked"
+				:disabled="(amount === '0' && !checked) || (disabled && !checked)"
 				:checked="checked"
 				:data-testid="addTestDataEnrichment('input', 'simple-checkbox', title, number)"
 				@change="updateSelection(!checked, title, fqkey)"
@@ -92,6 +92,10 @@ export default defineComponent({
 				return [] as SelectorData[];
 			},
 		},
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	setup(props) {
 		const searchResultStore = useSearchResultStore();
@@ -103,8 +107,10 @@ export default defineComponent({
 		const updateSelection = (checked: boolean, title: string | undefined, key: string | undefined) => {
 			props.update(props.parentArray, props.number, checked, title, key, searchResultStore.channelFilters);
 		};
-
-		return { displayAmount, addTestDataEnrichment, updateSelection };
+		const getClassStyle = () => {
+			return { 'checkbox-container': true, disabled: props.amount === '0' || (props.disabled && !props.checked) };
+		};
+		return { displayAmount, addTestDataEnrichment, updateSelection, getClassStyle };
 	},
 });
 </script>

--- a/src/components/search/CurrentFilters.vue
+++ b/src/components/search/CurrentFilters.vue
@@ -232,6 +232,7 @@ export default defineComponent({
 			resetAllSelectorValues(days.value);
 			resetAllSelectorValues(timeslots.value);
 			resetAllSelectorValues(months.value);
+			searchResultStore.queryLimitReached = false;
 			if (startDate.value !== null && endDate.value !== null) {
 				startDate.value.setTime(startYear.value.getTime());
 				endDate.value.setTime(endYear.value.getTime());

--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -47,6 +47,7 @@
 								:timeline="false"
 								:picker="true"
 								:init="false"
+								:disabled="searchResultStore.queryLimitReached"
 								@new-search="newSearch(true)"
 								@close="timeSearchStore.setTimeFacetsOpen(!timeSearchStore.timeFacetsOpen)"
 							></TimeSearchFilters>
@@ -91,6 +92,7 @@
 													:loading="searchResultStore.loadingGenres"
 													:update="updateCheckbox"
 													:parent-array="genreArray"
+													:disabled="searchResultStore.queryLimitReached"
 												/>
 											</div>
 										</TransitionGroup>
@@ -141,6 +143,7 @@
 													)
 												"
 												:loading="searchResultStore.loadingChannels"
+												:disabled="searchResultStore.queryLimitReached"
 											/>
 										</div>
 									</TransitionGroup>
@@ -155,7 +158,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watch } from 'vue';
+import { computed, defineComponent, onMounted, ref, watch } from 'vue';
 import { useSearchResultStore } from '@/store/searchResultStore';
 import { useTimeSearchStore } from '@/store/timeSearchStore';
 import { FacetResultType } from '@/types/GenericSearchResultTypes';
@@ -185,6 +188,7 @@ import {
 	startDate,
 	startYear,
 	timeslots,
+	calcEstimatedTimeSearchStringLength,
 } from '@/components/common/timeSearch/TimeSearchInitValues';
 import EdgedContentArea from '@/components/global/content-elements/EdgedContentArea.vue';
 import CustomExpander from '@/components/common/CustomExpander.vue';
@@ -433,6 +437,12 @@ export default defineComponent({
 				name: 'Search',
 				query: routeQueries,
 			});
+
+			if (searchResultStore.filterQueryLength > 900) {
+				searchResultStore.queryLimitReached = true;
+			} else {
+				searchResultStore.queryLimitReached = false;
+			}
 		};
 
 		const toggleTimeFacets = () => {

--- a/src/components/search/GenreCheckbox.vue
+++ b/src/components/search/GenreCheckbox.vue
@@ -37,7 +37,7 @@
 				role="checkbox"
 				type="checkbox"
 				class="checkbox"
-				:disabled="amount === '0' && !checked"
+				:disabled="(amount === '0' && !checked) || (disabled && !checked)"
 				:checked="checked"
 				:data-testid="addTestDataEnrichment('input', 'genre-checkbox', title, number)"
 				:name="title"
@@ -97,19 +97,20 @@ export default defineComponent({
 				return [] as SelectorData[];
 			},
 		},
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	setup(props) {
 		const searchResultStore = useSearchResultStore();
 		const { t } = useI18n();
 		const getStyles = () => {
-			let classes = 'category-item';
-			if (props.checked) {
-				classes += ' checked';
-			}
-			if (props.amount === '0') {
-				classes += ' disabled';
-			}
-			return classes;
+			return {
+				'category-item': true,
+				checked: props.checked,
+				disabled: props.amount === '0' || (props.disabled && !props.checked),
+			};
 		};
 
 		const displayAmount = (value: string | undefined) => {

--- a/src/components/search/SearchOverhead.vue
+++ b/src/components/search/SearchOverhead.vue
@@ -250,6 +250,7 @@ export default defineComponent({
 			resetAllSelectorValues(days.value);
 			resetAllSelectorValues(timeslots.value);
 			resetAllSelectorValues(months.value);
+			searchResultStore.queryLimitReached = false;
 			if (startDate.value !== null && endDate.value !== null) {
 				startDate.value.setTime(startYear.value.getTime());
 				endDate.value.setTime(endYear.value.getTime());

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -262,6 +262,10 @@
          "kbdk":"Søg i hjemmesiden",
          "webshop":"Søg i webshoppen"
       },
+      "limitedFilters":{
+         "title":"For mange filtre",
+         "subtitle":"Du er nået grænsen for antal af filtre vi understøtter. For at tilføjer et andet filter, bliver du nød til at fjerne et andet."
+      },
     "searchGuide": {
       "title":"Gode råd til din søgning",
       "subtitle": "Måske kan du forbedre din søgning med en af disse metoder",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -266,6 +266,10 @@
          "webshop":"Search in our webshop",
          "seeAllMaterials":"See all materials"
       },
+      "limitedFilters":{
+         "title":"Too many filters",
+         "subtitle":"You have reached the limit of filters we support. To add another filter, you have to remove another."
+    },
      "searchGuide": {
         "title":"Advice about searching",
         "subtitle": "Perhaps you can improve your search with one of these methods",


### PR DESCRIPTION
We disable the different checkboxes if the query size exceed 900 characters. 
Added functionality to keep track of days/ months/ timeslots filters, because checking them does not apply to the query until applied.
The all checkboxs's val was always set to false. I have made it so it follows, if all the checkboxes are set to selected, it is also selected. This is to keep the same functionality for the disabled property. 