### PR TITLE
DRA-1809: Date picker refinement.

### DIFF
--- a/src/utils/datepicker-utils.ts
+++ b/src/utils/datepicker-utils.ts
@@ -16,12 +16,14 @@ const updateSelectedDate = (
 	dateInput = dateInput.replace(/[.-]/g, '/');
 	const splitDateInput = dateInput.split('/');
 	if (splitDateInput.length === 3) {
-		const [day, month, year] = splitDateInput.map(Number);
+		const [day, month, yearInitial] = splitDateInput.map(Number);
+		let year = yearInitial;
 		// Validate if day, month, and year are numbers
 		if (!isNaN(day) && !isNaN(month) && !isNaN(year)) {
 			// Months in JavaScript Date are 0-indexed, so subtract 1 from the month
+			if (year.toString().length === 2) year = Number(`20${year}`);
 			const setDate = new Date(year, month - 1, day);
-
+			console.log(setDate);
 			// Ensure the date is valid
 			if (setDate.getDate() === day && setDate.getMonth() === month - 1 && setDate.getFullYear() === year) {
 				// Validate if the date is within the range
@@ -34,15 +36,22 @@ const updateSelectedDate = (
 					updateLink();
 					isDateValid.value = true;
 				} else {
+					console.log('NOP!');
 					isDateValid.value = false;
 				}
 			} else {
+				console.log('NOP!2');
+
 				isDateValid.value = false;
 			}
 		} else {
+			console.log('NOP3!');
+
 			isDateValid.value = false;
 		}
 	} else {
+		console.log('NOP4!');
+
 		isDateValid.value = false;
 	}
 };

--- a/src/utils/datepicker-utils.ts
+++ b/src/utils/datepicker-utils.ts
@@ -21,7 +21,13 @@ const updateSelectedDate = (
 		// Validate if day, month, and year are numbers
 		if (!isNaN(day) && !isNaN(month) && !isNaN(year)) {
 			// Months in JavaScript Date are 0-indexed, so subtract 1 from the month
-			if (year.toString().length === 2) year = Number(`20${year}`);
+			if (year.toString().length === 2) {
+				if (year < Number(new Date().getFullYear().toString().slice(-2))) {
+					year = Number(`20${year}`);
+				} else {
+					year = Number(`19${year}`);
+				}
+			}
 			const setDate = new Date(year, month - 1, day);
 			// Ensure the date is valid
 			if (setDate.getDate() === day && setDate.getMonth() === month - 1 && setDate.getFullYear() === year) {

--- a/src/utils/datepicker-utils.ts
+++ b/src/utils/datepicker-utils.ts
@@ -23,7 +23,6 @@ const updateSelectedDate = (
 			// Months in JavaScript Date are 0-indexed, so subtract 1 from the month
 			if (year.toString().length === 2) year = Number(`20${year}`);
 			const setDate = new Date(year, month - 1, day);
-			console.log(setDate);
 			// Ensure the date is valid
 			if (setDate.getDate() === day && setDate.getMonth() === month - 1 && setDate.getFullYear() === year) {
 				// Validate if the date is within the range
@@ -36,22 +35,15 @@ const updateSelectedDate = (
 					updateLink();
 					isDateValid.value = true;
 				} else {
-					console.log('NOP!');
 					isDateValid.value = false;
 				}
 			} else {
-				console.log('NOP!2');
-
 				isDateValid.value = false;
 			}
 		} else {
-			console.log('NOP3!');
-
 			isDateValid.value = false;
 		}
 	} else {
-		console.log('NOP4!');
-
 		isDateValid.value = false;
 	}
 };


### PR DESCRIPTION
This should ensure that if you enter 1-1-16 (fx), it is interpreted as 1-1-2016, and thus becomes valid (the calendar component actually does that right now, our own logic did not. This should align the two)