### PR TITLE
DRA-1981 noHits search by categories

### DIFF
--- a/src/components/search/NoHits.vue
+++ b/src/components/search/NoHits.vue
@@ -178,7 +178,6 @@ export default defineComponent({
 	color: white;
 	flex-wrap: wrap;
 	align-content: center;
-	padding: 20px 50px;
 	box-sizing: border-box;
 }
 


### PR DESCRIPTION
Search by categories did not have the same style on noHits as the frontpage, when using mobile. So I have removed the padding which seemed to have fixed it.