### PR TITLE
Added support for backend severity variable

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -264,10 +264,22 @@ export default defineComponent({
 					'messages-error',
 					t('error.title'),
 					typedResponse.data.alert1,
-					Severity.ERROR,
+					getSevertiyFromResponse(typedResponse.data.severity),
 					true,
 					Priority.HIGH,
 				);
+			}
+		};
+
+		const getSevertiyFromResponse = (severity?: Severity): Severity => {
+			if (severity === 1) {
+				return Severity.SUCCESS;
+			} else if (severity === 2) {
+				return Severity.INFO;
+			} else if (severity === 3) {
+				return Severity.WARNING;
+			} else {
+				return Severity.ERROR;
 			}
 		};
 

--- a/src/components/global/notification/Notifier.vue
+++ b/src/components/global/notification/Notifier.vue
@@ -38,7 +38,7 @@ import { defineComponent, onMounted, onUnmounted } from 'vue';
 import { useNotificationStore } from '@/store/notificationStore';
 import NotificationItem from '@/components/global/notification/NotificationItem.vue';
 import { NotificationType } from '@/types/NotificationType';
-import { Severity, Priority } from '@/types/NotificationType';
+// import { Severity, Priority } from '@/types/NotificationType';
 
 export default defineComponent({
 	name: 'Notifier',

--- a/src/types/APIResponseTypes.ts
+++ b/src/types/APIResponseTypes.ts
@@ -105,6 +105,7 @@ export interface CustomAxiosRequestConfig extends AxiosRequestConfig {
 
 export interface APIAuthMessagesType {
 	data: {
+		severity?: number;
 		alert1: string;
 		streamingBaseUrlVideo: string;
 		AudioUiConfId: string;


### PR DESCRIPTION
Now, if severity is added to the reponse, we take it into acount. If it's 1, we use the green success, 2 for the white info, 3 for the orange warning and 4 nothing added, red error.

Defensively coded so if nothing is added, its as it used to be.