### PR TITLE
DRA OPTIONAL timeFacetsOpen

### DIFF
--- a/src/components/common/TimeSearchComponent.vue
+++ b/src/components/common/TimeSearchComponent.vue
@@ -31,7 +31,7 @@
 							'timeSearch.result',
 							timeSearchStore.numFound,
 						)} `"
-						@click="scrollToTop()"
+						@click="timeSearchBehavior()"
 					></KBButton>
 				</div>
 				<div class="time-results">
@@ -73,7 +73,7 @@
 							'timeSearch.result',
 							timeSearchStore.numFound,
 						)} `"
-						@click="scrollToTop()"
+						@click="timeSearchBehavior()"
 					></KBButton>
 				</div>
 			</div>
@@ -137,7 +137,8 @@ export default defineComponent({
 			},
 		});
 
-		const scrollToTop = () => {
+		const timeSearchBehavior = () => {
+			timeSearchStore.timeFacetsOpen = true;
 			window.scrollTo({
 				top: 0,
 				behavior: 'smooth',
@@ -214,7 +215,7 @@ export default defineComponent({
 			getSublineForMonths,
 			getSublineForTimeslots,
 			addTestDataEnrichment,
-			scrollToTop,
+			timeSearchBehavior,
 		};
 	},
 });


### PR DESCRIPTION
We have a maybe unintended behavior when making a search via period. Because timeFacetsOpen remains false when the user clicks "Show xx.xxx results" from the frontpage. Then on the searchpage if you click show filters, and doesn't set date filter to true. The time period filter will be reset if another filter is added.