### PR TITLE
DRA BUGFIX FacetsContainer ref is null

### DIFF
--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -605,7 +605,17 @@ export default defineComponent({
 		watch(
 			() => searchResultStore.showFacets,
 			() => {
-				toggleFacets();
+				if (facetsContainer.value !== null) {
+					toggleFacets();
+				} else {
+					watch(
+						() => facetsContainer,
+						() => {
+							toggleFacets();
+						},
+						{ deep: true },
+					);
+				}
 			},
 		);
 


### PR DESCRIPTION
If you click show filters quickly after refresh. The backdrop appears, but the filter does not. It was because the gsap cannot see the facetsContainer yet, because its still null.  