### PR TITLE
DRA BUGFIX unable to remove all filters from category

### DIFF
--- a/src/components/search/Facets.vue
+++ b/src/components/search/Facets.vue
@@ -462,10 +462,7 @@ export default defineComponent({
 		};
 
 		const getSublineForFacets = (dataArray: SelectorData[], translationKey: string) => {
-			if (
-				dataArray.filter((item) => item.selected).length === 0 ||
-				dataArray.filter((item) => item.selected).length === dataArray.length
-			) {
+			if (dataArray.filter((item) => item.selected).length === 0) {
 				return ``;
 			} else {
 				const selected = dataArray.filter((item) => item.selected).length;


### PR DESCRIPTION
When checking all channels. The button to remove those selected channels change to a label, so you cant remove them all. This makes sure the KBButton stays even if all is checked. 