### PR TITLE
DRA-BUGFIX: gray icons when disabled.

### DIFF
--- a/src/components/common/SimpleCheckbox.vue
+++ b/src/components/common/SimpleCheckbox.vue
@@ -203,6 +203,10 @@ export default defineComponent({
 	background-image: url('@/assets/icons/blue/diverse-blue.svg');
 }
 
+.display-image.svg.disabled {
+	background-image: url('@/assets/icons/gray/diverse-gray.svg');
+}
+
 .display-image.channel {
 	background-size: contain;
 }

--- a/src/components/common/SimpleCheckbox.vue
+++ b/src/components/common/SimpleCheckbox.vue
@@ -199,10 +199,6 @@ export default defineComponent({
 	background-position: center center;
 }
 
-.display-image.disabled {
-	filter: grayscale(100%) brightness(4);
-}
-
 .display-image.svg {
 	background-image: url('@/assets/icons/blue/diverse-blue.svg');
 }
@@ -430,6 +426,40 @@ input:focus {
 }
 .svg.brn-og-unge {
 	background-image: url('@/assets/icons/blue/born-blue.svg');
+}
+
+.svg.diverse.disabled {
+	background-image: url('@/assets/icons/gray/diverse-gray.svg');
+}
+.svg.dokumentar.disabled {
+	background-image: url('@/assets/icons/gray/dokumentar-gray.svg');
+}
+.svg.film-og-serier.disabled {
+	background-image: url('@/assets/icons/gray/fiktion-gray.svg');
+}
+.svg.kultur-og-oplysning.disabled {
+	background-image: url('@/assets/icons/gray/kultur-gray.svg');
+}
+.svg.livsstil.disabled {
+	background-image: url('@/assets/icons/gray/livsstil-gray.svg');
+}
+.svg.musik.disabled {
+	background-image: url('@/assets/icons/gray/musik-gray.svg');
+}
+.svg.nyheder-politik-og-samfund.disabled {
+	background-image: url('@/assets/icons/gray/nyheder-gray.svg');
+}
+.svg.sport.disabled {
+	background-image: url('@/assets/icons/gray/sport-gray.svg');
+}
+.svg.humor-quiz-og-underholdning.disabled {
+	background-image: url('@/assets/icons/gray/underholdning-gray.svg');
+}
+.svg.natur-og-videnskab.disabled {
+	background-image: url('@/assets/icons/gray/videnskab-gray.svg');
+}
+.svg.brn-og-unge.disabled {
+	background-image: url('@/assets/icons/gray/born-gray.svg');
 }
 .label {
 	cursor: pointer;


### PR DESCRIPTION
Right color on the icons we use (the svg ones) when disabled, we used a filter. That wasn't the right color, so now we use the gray svgs when disabled instead.