### PR TITLE
Dra scroll gridresults frontpage

### DIFF
--- a/src/assets/styles/elements.css
+++ b/src/assets/styles/elements.css
@@ -1,6 +1,8 @@
 :root{
     /*background-colors*/
     --bg-main:#ea9fbc;
+    --bg-main-2: #F0BCD0;
+    --bg-main-3: #FBECF2;
     --bg-cta:#ea9fbc;
     --bg-light:#013277;
     --bg-remove:#f7ae3b;

--- a/src/components/common/GridDisplay.vue
+++ b/src/components/common/GridDisplay.vue
@@ -63,7 +63,9 @@ temporary styling until patterns from design system are implemented
 	margin-bottom: 80px;
 	margin-top: 34px;
 }
-
+.grid-display * {
+	gap: 0px;
+}
 .related-record.draggable-item {
 	margin-left: 20px;
 	flex: 0 0 30%;

--- a/src/components/common/GridDisplay.vue
+++ b/src/components/common/GridDisplay.vue
@@ -1,20 +1,27 @@
 <template>
 	<div class="grid-display">
-		<div :class="draggable ? 'record-grid draggable row-' + rowNr : 'record-grid row-' + rowNr">
-			<div
-				v-for="(item, i) in spotNr"
-				:key="i"
-				:class="draggable ? 'related-record draggable-item' : 'related-record'"
-			>
-				<GridResultItem
-					:loading="!loaded"
-					:resultdata="spots[i]"
-					:index="i"
-					background="var(--bg-default)"
-					:class="{ 'current-record': current === i }"
-				></GridResultItem>
-			</div>
-		</div>
+		<ItemSlider
+			:padding="true"
+			bg="var(--bg-secondary-light-20)"
+			item-class="rotational-results"
+		>
+			<template #default="slotProps">
+				<div
+					v-for="(item, i) in spotNr"
+					:key="i"
+					:class="'related-record draggable-item'"
+				>
+					<GridResultItem
+						:loading="!loaded"
+						:resultdata="spots[i]"
+						:index="i"
+						background="var(--bg-secondary-light-20)"
+						:class="{ 'current-record': current === i }"
+						:slot-props="slotProps"
+					></GridResultItem>
+				</div>
+			</template>
+		</ItemSlider>
 	</div>
 </template>
 
@@ -22,11 +29,13 @@
 import { defineComponent, PropType } from 'vue';
 import { GenericSearchResultType } from '@/types/GenericSearchResultTypes';
 import GridResultItem from '@/components/search/GridResultItem.vue';
+import ItemSlider from '@/components/search/ItemSlider.vue';
 
 export default defineComponent({
 	name: 'GridDisplay',
 	components: {
 		GridResultItem,
+		ItemSlider,
 	},
 	props: {
 		rowNr: { type: Number, required: true },
@@ -42,107 +51,6 @@ export default defineComponent({
 			},
 		},
 	},
-	data() {
-		return {
-			isDown: false,
-			startX: 0,
-			scrollLeft: 0 as number,
-			slidingElement: null as null | HTMLElement,
-			linkItems: null as null | NodeList,
-			move: false,
-		};
-	},
-
-	mounted() {
-		this.slidingElement = document.querySelector('.record-grid');
-		this.linkItems = document.querySelectorAll('.related-record');
-		if (this.slidingElement) {
-			this.slidingElement.addEventListener('mousedown', this.startAndCalculateOffset);
-			this.slidingElement.addEventListener('touchstart', this.startAndCalculateOffset, { passive: true });
-			this.slidingElement.addEventListener('mouseleave', this.stopMovementOnParent);
-			this.slidingElement.addEventListener('touchend', this.stopMovementOnParent, { passive: true });
-			this.slidingElement.addEventListener('mouseup', this.stopMovementOnParent);
-			this.slidingElement.addEventListener('mousemove', this.calculateMovement);
-			this.slidingElement.addEventListener('touchmove', this.calculateMovement, { passive: true });
-			this.linkItems.forEach((element) => {
-				element.addEventListener('mousedown', this.stopMovement);
-				element.addEventListener('touchstart', this.stopMovement, { passive: true });
-				element.addEventListener('mousemove', this.startMovement);
-				element.addEventListener('touchmove', this.startMovement, { passive: true });
-				element.addEventListener('click', this.preventClickIfMovement, { capture: true });
-			});
-		}
-	},
-	beforeUnmount() {
-		this.slidingElement = document.querySelector('.record-grid');
-		this.linkItems = document.querySelectorAll('.related-record');
-		if (this.slidingElement) {
-			this.slidingElement.removeEventListener('mousedown', this.startAndCalculateOffset);
-			this.slidingElement.removeEventListener('touchstart', this.startAndCalculateOffset);
-			this.slidingElement.removeEventListener('mouseleave', this.stopMovementOnParent);
-			this.slidingElement.removeEventListener('touchend', this.stopMovementOnParent);
-			this.slidingElement.removeEventListener('mouseup', this.stopMovementOnParent);
-			this.slidingElement.removeEventListener('mousemove', this.calculateMovement);
-			this.slidingElement.removeEventListener('touchmove', this.calculateMovement);
-
-			this.linkItems.forEach((element) => {
-				element.removeEventListener('mousedown', this.stopMovement);
-				element.removeEventListener('touchstart', this.stopMovement);
-				element.removeEventListener('mousemove', this.startMovement);
-				element.removeEventListener('touchmove', this.startMovement);
-				element.removeEventListener('click', this.preventClickIfMovement);
-			});
-		}
-	},
-
-	methods: {
-		startMovement() {
-			this.move = true;
-		},
-		stopMovement() {
-			this.move = false;
-		},
-		preventClickIfMovement(e: Event) {
-			if (this.move) {
-				e.preventDefault();
-			}
-		},
-
-		startAndCalculateOffset(e: MouseEvent | TouchEvent) {
-			if (this.slidingElement) {
-				this.isDown = true;
-				if (typeof TouchEvent !== 'undefined' && e instanceof TouchEvent) {
-					this.startX = e.touches[0].pageX - this.slidingElement.offsetLeft;
-				} else if (e instanceof MouseEvent) {
-					this.startX = e.pageX - this.slidingElement.offsetLeft;
-				}
-				this.scrollLeft = this.slidingElement.scrollLeft;
-			}
-		},
-		stopMovementOnParent() {
-			if (this.slidingElement) {
-				this.isDown = false;
-			}
-		},
-		calculateMovement(e: MouseEvent | TouchEvent) {
-			if (this.slidingElement) {
-				if (!this.isDown) {
-					return;
-				}
-				//e.preventDefault();
-
-				let x: number;
-				if (typeof TouchEvent !== 'undefined' && e instanceof TouchEvent) {
-					x = e.touches[0].pageX - this.slidingElement.offsetLeft;
-				} else if (e instanceof MouseEvent) {
-					x = e.pageX - this.slidingElement.offsetLeft;
-				} else {
-					return;
-				}
-				this.slidingElement.scrollLeft = this.scrollLeft - (x - this.startX);
-			}
-		},
-	},
 });
 </script>
 
@@ -153,127 +61,22 @@ temporary styling until patterns from design system are implemented
 .grid-display {
 	position: relative;
 	margin-bottom: 80px;
-}
-
-.record-grid {
-	display: flex;
-	flex-wrap: wrap;
-	padding-left: 0;
-	max-width: 100%;
-	overflow: hidden;
-	padding-top: 5px;
-}
-
-.draggable {
-	flex-wrap: wrap;
-}
-
-.current-record {
-	background-color: #c4f1ed !important;
-	border: 1px solid #0a2e70;
-	box-shadow: 0 0 15 black;
-}
-
-@media (min-width: 321px) {
-	.draggable {
-		flex-wrap: nowrap;
-	}
-}
-
-.draggable-item {
-	flex: 0 0 100%;
-	margin: 0px;
+	margin-top: 34px;
 }
 
 .related-record.draggable-item {
 	margin-left: 20px;
-	flex: 0 0 90%;
+	flex: 0 0 30%;
 	box-sizing: border-box;
+	background-color: var(--bg-secondary-light-20);
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	-o-user-select: none;
+	user-select: none;
+	user-drag: none;
 }
 .related-record.draggable-item:first-of-type {
 	margin-left: 0px;
-}
-
-@media (min-width: 640px) {
-	.record-grid {
-		flex: 0 0 100%;
-		max-width: 100%;
-	}
-	.row-4 .related-record {
-		flex: 0 0 100%;
-	}
-
-	.row-4 .related-record.draggable-item {
-		flex: 0 0 66.6666%;
-	}
-	.row-3 .related-record.draggable-item {
-		flex: 0 0 66.6666%;
-	}
-}
-
-/* Second break for small screen */
-@media (min-width: 800px) {
-	.record-grid {
-		flex: 0 0 100%;
-		max-width: 100%;
-		flex-wrap: wrap;
-	}
-	.row-3 .related-record,
-	.row-3 .related-record.draggable-item {
-		margin: 0px;
-		flex: 0 0 33.3333%;
-		box-sizing: border-box;
-	}
-	.row-4 .related-record,
-	.row-4 .related-record.draggable-item {
-		margin: 0px;
-		flex: 0 0 25%;
-		box-sizing: border-box;
-	}
-	.row-3 .related-record:nth-of-type(3n + 1) {
-		padding-left: 0px;
-		padding-right: 10px;
-	}
-	.row-3 .related-record:nth-of-type(3n + 2) {
-		padding-left: 5px;
-		padding-right: 5px;
-	}
-	.row-3 .related-record:nth-of-type(3n) {
-		padding-right: 0px;
-		padding-left: 10px;
-	}
-	.row-4 .related-record:nth-of-type(4n + 1) {
-		padding-left: 0px;
-		padding-right: 10px;
-	}
-	.row-4 .related-record:nth-of-type(4n + 2) {
-		padding-left: 5px;
-		padding-right: 7.5px;
-	}
-	.row-4 .related-record:nth-of-type(4n + 3) {
-		padding-left: 7.5px;
-		padding-right: 5px;
-	}
-	.row-4 .related-record:nth-of-type(4n) {
-		padding-right: 0px;
-		padding-left: 10px;
-	}
-}
-
-/* third break for large screen */
-@media (min-width: 990px) {
-	.row-3 div {
-		flex: 0 0 33.3333%;
-		box-sizing: border-box;
-	}
-
-	.row-4 div {
-		flex: 0 0 25%;
-		box-sizing: border-box;
-	}
-	.related-records {
-		flex: 0 0 100%;
-		max-width: 100%;
-	}
 }
 </style>

--- a/src/components/common/PortalContent.vue
+++ b/src/components/common/PortalContent.vue
@@ -19,16 +19,18 @@
 				></TimeSearchComponent>
 			</SkewedFoldable>
 		</div>
-		<TiltedDivider
-			:right="false"
-			:title="
-				$t('frontpage.fromTheArchive', {
-					month: new Date().toLocaleString(currentLocale, { month: 'long' }),
-				})
-			"
-			:data-testid="addTestDataEnrichment('TiltedDivider', 'PortalContent', 'through-time-header', 0)"
-		></TiltedDivider>
+		<div class="title">
+			<h2 class="heading-display">
+				{{ t('frontpage.fromTheArchive', { month: new Date().toLocaleDateString(currentLocale, { month: 'long' }) }) }}
+			</h2>
+		</div>
+
 		<div class="container">
+			<div class="container-backdrop">
+				<ContainerSplitBar :is-top="true"></ContainerSplitBar>
+				<ContainerSplitBar :is-top="false"></ContainerSplitBar>
+			</div>
+
 			<GridDisplay
 				:spot-nr="searchResultStore.rotationalResult.length === 0 ? 4 : searchResultStore.rotationalResult.length"
 				:row-nr="4"
@@ -46,7 +48,6 @@ import { useSearchResultStore } from '@/store/searchResultStore';
 import GridDisplay from '@/components/common/GridDisplay.vue';
 import { GenericSearchResultType } from '@/types/GenericSearchResultTypes';
 import TimeSearchComponent from '@/components/common/TimeSearchComponent.vue';
-import TiltedDivider from '@/components/global/content-elements/TiltedDivider.vue';
 import { addTestDataEnrichment } from '@/utils/test-enrichments';
 import SkewedFoldable from '@/components/common/SkewedFoldable.vue';
 import router from '@/router';
@@ -57,14 +58,15 @@ import { APISearchResponseType } from '@/types/APIResponseTypes';
 import { Priority, Severity } from '@/types/NotificationType';
 import { ErrorManagerType } from '@/types/ErrorManagerType';
 import { CuratedItemsType } from '@/types/CuratedItemsType';
+import ContainerSplitBar from '@/components/global/content-elements/ContainerSplitBar.vue';
 
 export default defineComponent({
 	name: 'PortalContent',
 	components: {
 		GridDisplay,
 		TimeSearchComponent,
-		TiltedDivider,
 		SkewedFoldable,
+		ContainerSplitBar,
 	},
 
 	setup() {
@@ -198,6 +200,10 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.title {
+	width: 100%;
+	color: var(--color-main);
+}
 .time-search {
 	background-color: var(--bg-default);
 	margin-bottom: -70px;
@@ -216,8 +222,22 @@ export default defineComponent({
 }
 
 .container {
-	background-color: var(--bg-default);
+	background-color: var(--bg-secondary-light-20);
 	width: 100%;
+	position: relative;
+	display: flex;
+	justify-content: center;
+	flex-direction: column;
+	align-items: center;
+}
+.container-backdrop {
+	position: absolute;
+	height: 100%;
+	width: 100vw;
+	background-color: var(--bg-secondary-light-20);
+	justify-content: space-between;
+	display: flex;
+	flex-direction: column;
 }
 
 .categories {

--- a/src/components/common/TimeSearchComponent.vue
+++ b/src/components/common/TimeSearchComponent.vue
@@ -15,68 +15,54 @@
 				:init="true"
 				@new-search="fetchNewTimeResults()"
 			></TimeSearchFilters>
+
 			<div class="result-container">
-				<div class="result-header">
-					<h2 class="selection-header">{{ t('timeSearch.selection') }}:</h2>
-					<KBButton
-						class="btn-medium"
-						:to="timeSearchLink"
-						:data-testid="addTestDataEnrichment('link', 'time-search-component', `top-more-link`, 0)"
-						button-type="btn-cta"
-						button-color="cta"
-						button-size="medium"
-						:is-router-link="true"
-						right-icon-name="arrow_forward_ios"
-						:button-text="`Vis ${new Intl.NumberFormat('de-DE').format(timeSearchStore.numFound)} ${$t(
-							'timeSearch.result',
-							timeSearchStore.numFound,
-						)} `"
-						@click="timeSearchBehavior()"
-					></KBButton>
+				<div class="container-backdrop">
+					<ContainerSplitBar :is-top="true"></ContainerSplitBar>
+					<ContainerSplitBar :is-top="false"></ContainerSplitBar>
 				</div>
 				<div class="time-results">
-					<div
-						v-for="(item, index) in timeSearchStore.timeResults"
-						:key="index"
-						class="time-result-item"
+					<ItemSlider
+						:padding="true"
+						bg="var(--bg-secondary-light-20)"
+						item-class="time-result"
 					>
-						<GridResultItem
-							:loading="timeSearchStore.loading"
-							:resultdata="item"
-							:index="index"
-							background="var(--bg-default)"
-						></GridResultItem>
+						<template #default="slotProps">
+							<div
+								v-for="(item, index) in timeSearchStore.timeResults"
+								:key="index"
+								class="time-result-item"
+							>
+								<GridResultItem
+									:loading="timeSearchStore.loading"
+									:resultdata="item"
+									:index="index"
+									background="var(--bg-secondary-light-20)"
+									:slot-props="slotProps"
+								></GridResultItem>
+							</div>
+						</template>
+					</ItemSlider>
+					<div class="result-header">
+						<KBButton
+							class="btn-medium"
+							:to="timeSearchLink"
+							:data-testid="addTestDataEnrichment('link', 'time-search-component', `top-more-link`, 0)"
+							button-type="btn-cta"
+							button-color="cta"
+							button-size="medium"
+							:is-router-link="true"
+							right-icon-name="arrow_forward_ios"
+							:button-text="`Vis ${new Intl.NumberFormat('de-DE').format(timeSearchStore.numFound)} ${$t(
+								'timeSearch.result',
+								timeSearchStore.numFound,
+							)} `"
+							@click="timeSearchBehavior()"
+						></KBButton>
 					</div>
 				</div>
 			</div>
-			<div class="further-recap">
-				<div class="further-link">
-					<div class="recap label-small">
-						<span>{{ `${getYears(timeSliderValues)} ${t('timeSearch.year', getYears(timeSliderValues))}` }}</span>
-						/
-						<span>{{ getSublineForMonths(months, t) }}</span>
-						/
-						<span>{{ getSublineForDays(days, t) }}</span>
-						/
-						<span>{{ getSublineForTimeslots(timeslots, t) }}</span>
-					</div>
-					<KBButton
-						class="btn-medium"
-						:to="timeSearchLink"
-						:data-testid="addTestDataEnrichment('link', 'time-search-component', `bottom-more-link`, 0)"
-						button-type="btn-cta"
-						button-color="cta"
-						button-size="medium"
-						:is-router-link="true"
-						right-icon-name="arrow_forward_ios"
-						:button-text="`Vis ${new Intl.NumberFormat('de-DE').format(timeSearchStore.numFound)} ${$t(
-							'timeSearch.result',
-							timeSearchStore.numFound,
-						)} `"
-						@click="timeSearchBehavior()"
-					></KBButton>
-				</div>
-			</div>
+			<ContainerSplitBar :is-top="false"></ContainerSplitBar>
 		</template>
 	</EdgedContentArea>
 </template>
@@ -109,7 +95,8 @@ import { addTestDataEnrichment } from '@/utils/test-enrichments';
 
 import '@/assets/styles/vue-slider-styles.css';
 import KBButton from '@/components/common/KBButton.vue';
-
+import ItemSlider from '@/components/search/ItemSlider.vue';
+import ContainerSplitBar from '@/components/global/content-elements/ContainerSplitBar.vue';
 export default defineComponent({
 	name: 'TimeSearchComponent',
 	components: {
@@ -117,6 +104,8 @@ export default defineComponent({
 		EdgedContentArea,
 		TimeSearchFilters,
 		KBButton,
+		ItemSlider,
+		ContainerSplitBar,
 	},
 	props: {
 		title: { type: String, default: '' },
@@ -228,69 +217,48 @@ h2 {
 
 .result-container {
 	width: 100%;
-	padding-top: 45px;
-}
-
-.result-header {
+	position: relative;
 	display: flex;
+	justify-content: center;
+	height: 100%;
+}
+.container-backdrop {
+	position: absolute;
+	height: 100%;
+	width: 100vw;
+	background-color: var(--bg-secondary-light-20);
 	justify-content: space-between;
-	padding-bottom: 20px;
+	display: flex;
 	flex-direction: column;
 }
-
-.further-link a:visited {
+.result-header {
+	display: flex;
+	padding-top: 20px;
+	padding-bottom: 20px;
+	justify-content: end;
 }
 
 .selection-header {
 	color: var(--color-main);
-	padding-top: 4px;
-}
-
-.further-recap {
-	width: 100%;
-	display: flex;
-	justify-content: flex-end;
-}
-
-.recap {
-	padding-bottom: 10px;
-}
-
-.recap span {
-	background-color: var(--bg-default);
-	color: var(--color-main);
-	border-radius: 4px;
-	width: fit-content;
-	padding-left: 3px;
-	padding-right: 3px;
-}
-
-.further-link {
-	display: flex;
-	align-items: flex-end;
-	flex-direction: column;
-}
-
-.further-results {
-	display: flex;
-	align-items: flex-end;
-	flex-direction: column;
-	justify-content: center;
 }
 
 .time-results {
-	display: flex;
-	flex-direction: row;
-	flex-wrap: nowrap;
-	gap: 20px;
-	flex-wrap: wrap;
-	padding-bottom: 20px;
+	position: relative;
+	margin-top: 34px;
+	margin-bottom: 34px;
 }
 
 .time-result-item {
-	flex: 1 1 calc(100%);
-	max-width: calc(100%);
+	margin-left: 20px;
+	flex: 0 0 30%;
 	box-sizing: border-box;
+	background-color: var(--bg-secondary-light-20);
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	-o-user-select: none;
+	user-select: none;
+	user-drag: none;
 }
 
 .header {
@@ -315,44 +283,5 @@ h2 {
 }
 .header p {
 	margin: 0;
-}
-@media (max-width: 480px) {
-	.time-result-item:nth-child(n + 3) {
-		display: none;
-	}
-}
-
-@media (max-width: 990px) {
-	.time-result-item:nth-child(n + 5) {
-		display: none;
-	}
-	.result-container {
-		padding-top: 85px;
-	}
-}
-
-@media (min-width: 480px) {
-	.time-result-item {
-		flex: 1 1 calc(50% - 20px);
-		max-width: calc(50% - 15px);
-		box-sizing: border-box;
-	}
-	.result-header {
-		flex-direction: unset;
-	}
-}
-/* MEDIA QUERY 990 */
-@media (min-width: 990px) {
-	.figures {
-		top: 0px;
-	}
-	.time-result-item {
-		flex: 1 1 calc(25% - 20px);
-		max-width: calc(25% - 15px);
-		box-sizing: border-box;
-	}
-	.header {
-		display: block;
-	}
 }
 </style>

--- a/src/components/common/TimeSearchComponent.vue
+++ b/src/components/common/TimeSearchComponent.vue
@@ -248,8 +248,12 @@ h2 {
 	margin-bottom: 34px;
 }
 
+.time-results * {
+	gap: 0px;
+}
+
 .time-result-item {
-	margin-left: 20px;
+	margin-left: 15px;
 	flex: 0 0 30%;
 	box-sizing: border-box;
 	background-color: var(--bg-secondary-light-20);

--- a/src/components/common/timeSearch/TimeSearchFilters.vue
+++ b/src/components/common/timeSearch/TimeSearchFilters.vue
@@ -421,7 +421,7 @@ export default defineComponent({
 	justify-content: space-evenly;
 	align-items: center;
 	gap: 10px;
-	margin-bottom: 30px;
+	margin-bottom: 0px;
 	font-size: 26px;
 	text-transform: capitalize;
 }
@@ -983,6 +983,9 @@ fieldset {
 	}
 	.slider-container {
 		height: 200px;
+	}
+	.to-from-container {
+		margin-bottom: 30px;
 	}
 }
 

--- a/src/components/global/content-elements/ContainerSplitBar.vue
+++ b/src/components/global/content-elements/ContainerSplitBar.vue
@@ -1,0 +1,35 @@
+<template>
+	<div class="bar-container">
+		<div
+			class="bar"
+			:class="`${isTop ? 'bar-1' : 'bar-2'}`"
+		></div>
+		<div
+			class="bar"
+			:class="`${isTop ? 'bar-2' : 'bar-1'}`"
+		></div>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+	name: 'ContainerSplitBar',
+	props: {
+		isTop: { type: Boolean, required: true },
+	},
+});
+</script>
+<style scoped>
+.bar {
+	height: 17px;
+	width: 100%;
+}
+.bar-1 {
+	background-color: var(--bg-main-2);
+}
+.bar-2 {
+	background-color: var(--bg-main-3);
+}
+</style>

--- a/src/components/search/GridResultItem.vue
+++ b/src/components/search/GridResultItem.vue
@@ -15,6 +15,7 @@
 			>
 				<router-link
 					:to="{ name: 'Record', params: { id: resultdata.id } }"
+					v-bind="slotProps"
 					draggable="false"
 					class="link-title"
 					role="link"
@@ -175,6 +176,12 @@ export default defineComponent({
 			type: Number as PropType<number>,
 			required: true,
 		},
+		slotProps: {
+			type: Object,
+			default() {
+				return {};
+			},
+		},
 		loading: { type: Boolean as PropType<boolean>, required: true },
 		background: { type: String as PropType<string>, required: false, default: 'var(--bg-default)' },
 		fullPostUrl: {
@@ -296,11 +303,11 @@ export default defineComponent({
 .grid-result-item {
 	width: 100%;
 	max-width: 100%;
-	border-bottom: 1px solid var(--color-border-active);
+	border-bottom: 1px solid var(--color-border-success);
 	padding-bottom: 20px;
 	margin-bottom: 10px;
 	position: relative;
-	color: var(--color-main);
+	color: var(--color-default);
 	background-color: var(--bg-default);
 }
 
@@ -311,7 +318,7 @@ export default defineComponent({
 .link-title {
 	font-size: 14px;
 	text-decoration: none;
-	color: var(--color-main);
+	color: var(--color-default);
 	display: grid;
 }
 
@@ -336,7 +343,7 @@ export default defineComponent({
 	aspect-ratio: 4/2;
 	text-align: center;
 	align-content: center;
-	color: var(--color-main);
+	color: var(--color-default);
 }
 
 .loading-color {
@@ -402,7 +409,7 @@ export default defineComponent({
 
 .title {
 	font-weight: var(--fw-bold);
-	color: var(--color-main);
+	color: var(--color-default);
 	margin-bottom: 10px;
 	max-width: 100%;
 	text-overflow: ellipsis;
@@ -419,10 +426,10 @@ export default defineComponent({
 	height: 20px;
 }
 .episode-text {
-	color: var(--color-main);
+	color: var(--color-default);
 }
 .title.loading {
-	background-color: var(--color-main);
+	background-color: var(--color-default);
 	border-radius: 10px;
 	margin-top: 15px;
 }


### PR DESCRIPTION
We wish to have slider view for the result items on the frontpage. So it takes up less vertical space.
This reuses the ItemSlider component and makes the adjustments so its usable.
Reason to reuse the component is to keep the same scoll speed logic throughout the site.