### PR TITLE
DRA 2863 searchbar full width

### DIFF
--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -278,7 +278,12 @@ input[type='search']::-webkit-search-results-decoration {
 .search-box {
 	z-index: 6;
 	left: 0;
+	/* Chromium */
 	width: stretch;
+	/* Firefox */
+	width: -moz-available;
+	/* Safari */
+	width: -webkit-fil-available;
 	border-radius: var(--rounded-small);
 	display: flex;
 	position: absolute;

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -283,7 +283,7 @@ input[type='search']::-webkit-search-results-decoration {
 	/* Firefox */
 	width: -moz-available;
 	/* Safari */
-	width: -webkit-fil-available;
+	width: -webkit-fill-available;
 	border-radius: var(--rounded-small);
 	display: flex;
 	position: absolute;


### PR DESCRIPTION
When on the search page, the searchbar was not full width, but it was because I used Firefox. width: stretch is not supported on Firefox and Safari it seems. But they have their own version of stretch, so I added those.