### PR TITLE
DRA 2867 advanced spot adjustment

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -441,6 +441,7 @@ export default defineComponent({
 	span {
 		border-bottom: 1px solid white;
 	}
+	pointer-events: none;
 }
 
 /* SEARCH TO HOME TRANSITION */

--- a/src/components/common/AdvancedSpot.vue
+++ b/src/components/common/AdvancedSpot.vue
@@ -10,18 +10,18 @@
 				class="hero-info"
 			>
 				<div class="info">
-					<div class="progress-headline">
-						<h2>{{ t('hero.progress', { index: Math.round(currentProgress) }) }}</h2>
-						<p>
-							{{ t('hero.explanation') }}
-						</p>
-					</div>
 					<div class="process-bar">
 						<div
 							v-for="i in 20"
 							:key="i"
 							:class="progress(i)"
 						></div>
+					</div>
+					<div class="progress-headline">
+						<h2>{{ t('hero.progress', { index: Math.round(currentProgress) }) }}</h2>
+						<p>
+							{{ t('hero.explanation') }}
+						</p>
 					</div>
 				</div>
 			</div>
@@ -99,6 +99,9 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.progress-headline {
+	margin-top: 20px;
+}
 .progress-headline > * {
 	margin: 0;
 }
@@ -129,8 +132,9 @@ export default defineComponent({
 	position: absolute;
 	width: 100%;
 	left: 0px;
-	bottom: 0px;
+	top: 0px;
 	background-color: var(--bg-default);
+	z-index: 1;
 }
 
 .step {

--- a/src/components/common/SimpleSpot.vue
+++ b/src/components/common/SimpleSpot.vue
@@ -59,7 +59,14 @@ export default defineComponent({
 	overflow: hidden;
 	flex-wrap: wrap;
 	align-content: baseline;
+}
+.spot::after {
+	content: '';
+	position: absolute;
+	inset: 0;
 	box-shadow: 0 0 14px 0 rgba(0, 0, 0, 0.34) inset;
+	pointer-events: none;
+	z-index: 2;
 }
 .spot .icon {
 	width: 40px;


### PR DESCRIPTION
process bar spot according to design needs to be above the text. Found that shadow box looked better if its above the process bar. The test-env header blocked the localization button