### PR TITLE
DRA 2874 spots changes

### DIFF
--- a/src/components/common/SimpleSpot.vue
+++ b/src/components/common/SimpleSpot.vue
@@ -85,6 +85,7 @@ export default defineComponent({
 	justify-content: start;
 	align-items: flex-start;
 	text-align: start;
+	flex-direction: column;
 	/* word-break: break-all; */
 }
 .spot.main {

--- a/src/components/common/SpotCategories.vue
+++ b/src/components/common/SpotCategories.vue
@@ -8,7 +8,7 @@
 			v-if="categoriesLoaded && categories.length"
 			class="spot-categories"
 		>
-			<h3>{{ categories.length }} kategorier:</h3>
+			<h3>{{ categories.length }} {{ t('facets.genres', 2) }}:</h3>
 			<KBButton
 				v-for="(category, i) in categories"
 				:key="category.name"
@@ -42,7 +42,7 @@
 					class="shimmer"
 				></div>
 				<span class="loading"></span>
-				<h3>kategorier:</h3>
+				<h3>{{ t('facets.genres', 2) }}:</h3>
 			</div>
 
 			<div

--- a/src/components/common/SpotContainer.vue
+++ b/src/components/common/SpotContainer.vue
@@ -4,11 +4,8 @@
 			<spot-categories></spot-categories>
 		</div>
 		<div class="spot-row">
-			<simple-spot spot-size="small">
-				<span class="label-big">En kasse til noget display 349.994 minutters noget helt tilbage fra 1931.</span>
-			</simple-spot>
 			<simple-spot
-				spot-size="small"
+				spot-size="medium"
 				icon-name="link"
 				color="light"
 				class="spot-link"
@@ -21,6 +18,7 @@
 				>
 					{{ t('hero.linkText') }}
 				</a>
+				<p class="label-reg">{{ t('spots.readMoreSubtitle') }}</p>
 			</simple-spot>
 			<advanced-spot spot-size="medium"></advanced-spot>
 		</div>

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -345,6 +345,9 @@
   "notification": {
       "close":"Luk notifikation"
   },
+  "spots": {
+   "readMoreSubtitle":"Før du går på opdagelse, kan du læse om arkivets indhold, baggrund og begrænsninger - og få gode råd til at søge i næsten 100 års radio og tv."
+  },
   "footer": {
     "contactInfo":"Kontaktinformationer",
     "cookie":"Cookieindstillinger",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -348,6 +348,9 @@
   "notification": {
       "close":"Close notification"
    },
+   "spots": {
+      "readMoreSubtitle":"Before going on descovery you can read about the archives content, background and limitations - and get some good advice to search in nearly a 100 years of radio and TV."
+  },
    "footer": {
       "contactInfo":"Contact information",
       "cookie":"Cookie Settings",


### PR DESCRIPTION
Its been decided that the info spot will be removed, and the read more spot will be larger.
Read more gained some more text, so I've added localization for that text and for categories title.

Cannot remember what was decided about the spot height. The read more has gained more content, and thereby more height, especially with English text. 
The English translation was done by me, has not been through UX or PO.