### PR TITLE
DRA-OPTIONAL: Enhance frontpage styles and components

### DIFF
--- a/src/assets/styles/elements.css
+++ b/src/assets/styles/elements.css
@@ -37,6 +37,7 @@
     --color-border-transparent: transparent;
     --color-border-light-focused: #96E2FD;
     --color-borders-light: #96E2FD;
+    --color-border-success-transparent: #ea9fbc3d;
 
     /*rounded*/
     --rounded-small: var(--scale-50);

--- a/src/assets/styles/font-styles.css
+++ b/src/assets/styles/font-styles.css
@@ -32,6 +32,10 @@ body,button{
     font-family: noway, sans-serif;
 }
 
+h1, h2 {
+    font-family: 'LibreBaskerville';
+}
+
 @font-face {
 	font-family: 'noway';
 	font-style: normal;

--- a/src/components/common/AdvancedSpot.vue
+++ b/src/components/common/AdvancedSpot.vue
@@ -4,19 +4,22 @@
 		:color="color"
 		:icon-name="iconName"
 	>
-		<transition name="fade">
+		<TransitionGroup name="fade">
+			<div
+				v-show="authStore.currentArchiveProgress !== 0"
+				class="process-bar"
+			>
+				<div
+					v-for="i in 20"
+					:key="i"
+					:class="progress(i)"
+				></div>
+			</div>
 			<div
 				v-show="authStore.currentArchiveProgress !== 0"
 				class="hero-info"
 			>
 				<div class="info">
-					<div class="process-bar">
-						<div
-							v-for="i in 20"
-							:key="i"
-							:class="progress(i)"
-						></div>
-					</div>
 					<div class="progress-headline">
 						<h2>{{ t('hero.progress', { index: Math.round(currentProgress) }) }}</h2>
 						<p>
@@ -25,12 +28,12 @@
 					</div>
 				</div>
 			</div>
-		</transition>
+		</TransitionGroup>
 	</simple-spot>
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, PropType, ref, watch } from 'vue';
+import { defineComponent, onMounted, PropType, ref, TransitionGroup, watch } from 'vue';
 import SimpleSpot from '@/components/common/SimpleSpot.vue';
 import { useAuthStore } from '@/store/authStore';
 import gsap from 'gsap';
@@ -99,9 +102,6 @@ export default defineComponent({
 </script>
 
 <style scoped>
-.progress-headline {
-	margin-top: 20px;
-}
 .progress-headline > * {
 	margin: 0;
 }
@@ -109,10 +109,8 @@ export default defineComponent({
 .hero-info {
 	max-width: 100%;
 	/* position: relative; */
-	z-index: 0;
 	display: flex;
 	box-sizing: border-box;
-	height: 150px;
 	justify-content: flex-start;
 }
 
@@ -127,22 +125,23 @@ export default defineComponent({
 }
 
 .process-bar {
-	height: 34px;
+	height: 40px;
 	display: flex;
+	width: calc(100% + 1px);
 	position: absolute;
-	width: 100%;
 	left: 0px;
-	top: 0px;
+	top: -40px;
 	background-color: var(--bg-default);
-	z-index: 1;
 }
 
 .step {
 	width: 5%;
 	height: 100%;
 	box-sizing: border-box;
-	border-left: 1px solid rgba(255, 255, 255, 0.05);
+	border-left: 1px solid var(--bg-main);
 	transition: all 0.15s ease-in-out 0s;
+	position: relative;
+	z-index: 1;
 }
 
 .step.darkblue {
@@ -156,20 +155,32 @@ export default defineComponent({
 .step.lightblue {
 	background-color: var(--bg-main);
 	opacity: 0.85;
+	z-index: 5;
+	height: calc(100% + 2px);
+	margin-top: -1px;
 }
 
 .step.grey {
 	background-color: var(--bg-main);
 	opacity: 0.75;
+	z-index: 5;
+	height: calc(100% + 2px);
+	margin-top: -1px;
 }
 
 .step.lightgrey {
 	background-color: var(--bg-main);
 	opacity: 0.7;
+	z-index: 5;
+	height: calc(100% + 2px);
+	margin-top: -1px;
 }
 
 .step.white {
-	background-color: transparent;
+	background-color: var(--bg-default);
 	border-color: transparent;
+	z-index: 5;
+	height: calc(100% + 2px);
+	margin-top: -2px;
 }
 </style>

--- a/src/components/common/PortalContent.vue
+++ b/src/components/common/PortalContent.vue
@@ -4,7 +4,6 @@
 		<div class="time-search">
 			<TimeSearchComponent
 				:title="$t('timeSearch.timeMachine')"
-				:subtitle="$t('timeSearch.timeMachineSubtitle')"
 				text="var(--color-main)"
 			></TimeSearchComponent>
 		</div>

--- a/src/components/common/SimpleSpot.vue
+++ b/src/components/common/SimpleSpot.vue
@@ -11,6 +11,10 @@
 				{{ iconName }}
 			</span>
 		</div>
+		<div
+			v-else
+			class="icon"
+		></div>
 		<div class="inner"><slot></slot></div>
 	</div>
 </template>
@@ -53,10 +57,9 @@ export default defineComponent({
 	height: 100%;
 	min-height: 190px;
 	border-radius: 0px;
-	border: 1px solid var(--color-border-success);
+	border: 1px solid var(--color-border-success-transparent);
 	box-sizing: border-box;
 	position: relative;
-	overflow: hidden;
 	flex-wrap: wrap;
 	align-content: baseline;
 }
@@ -86,13 +89,14 @@ export default defineComponent({
 }
 .spot .inner {
 	width: 100%;
-	height: inherit;
 	padding: 20px;
+	height: calc(100% - 80px);
 	display: flex;
 	justify-content: start;
 	align-items: flex-start;
 	text-align: start;
 	flex-direction: column;
+	position: relative;
 	/* word-break: break-all; */
 }
 .spot.main {
@@ -110,6 +114,7 @@ export default defineComponent({
 .spot.medium {
 	width: 100%;
 	max-width: 100%;
+	height: 200px;
 }
 .spot.large {
 	width: 100%;

--- a/src/components/common/SpotCategories.vue
+++ b/src/components/common/SpotCategories.vue
@@ -8,7 +8,7 @@
 			v-if="categoriesLoaded && categories.length"
 			class="spot-categories"
 		>
-			<h3>{{ categories.length }} {{ t('facets.genres', 2) }}:</h3>
+			<h1>{{ categories.length }} {{ t('facets.genres', 2) }}:</h1>
 			<KBButton
 				v-for="(category, i) in categories"
 				:key="category.name"
@@ -165,6 +165,11 @@ h3 {
 	flex-wrap: wrap;
 	align-items: baseline;
 }
+
+.spot-categories h1 {
+	padding-right: 15px;
+}
+
 .spot-categories > * {
 	margin-right: 3px;
 	margin-left: 7px;

--- a/src/components/common/SpotContainer.vue
+++ b/src/components/common/SpotContainer.vue
@@ -54,6 +54,7 @@ export default defineComponent({
 	height: 100%;
 	flex-direction: column;
 	margin-bottom: 20px;
+	gap: 50px;
 }
 .spot-row {
 	display: flex;
@@ -62,13 +63,17 @@ export default defineComponent({
 	height: 100%;
 	flex-wrap: wrap;
 	/* background-repeat: no-repeat; */
-
 	justify-content: space-between;
 }
 .link {
 	color: inherit;
 	text-decoration: inherit;
 	border-bottom: 1px solid transparent;
+	font-size: var(--fs-md);
+	line-height: var(--lh-medium-tight);
+	font-weight: var(--fw-regular);
+	font-family: 'LibreBaskerville';
+	margin: 0px;
 }
 
 .spot-link:hover {

--- a/src/components/common/TimeSearchComponent.vue
+++ b/src/components/common/TimeSearchComponent.vue
@@ -3,7 +3,7 @@
 		class="header"
 		:style="`color: ${text}`"
 	>
-		<h2 class="heading-sub">{{ title }}</h2>
+		<h1>{{ title }}</h1>
 		<p>
 			<span>{{ subtitle }}</span>
 		</p>

--- a/src/components/common/timeSearch/TimeSearchFilters.vue
+++ b/src/components/common/timeSearch/TimeSearchFilters.vue
@@ -29,6 +29,10 @@
 				:label="$t('timeSearch.to')"
 				@update-selected="updateEndYear"
 			/>
+			<p class="year-count label-regular">
+				<span class="equal-sign">=</span>
+				{{ $t('timeSearch.periodOf', { number: Math.ceil(timeSliderValues[1] - timeSliderValues[0] + 1) }) }}
+			</p>
 		</div>
 		<div class="slider-whiteoff-container">
 			<Transition name="fade">
@@ -423,6 +427,15 @@ export default defineComponent({
 	margin-bottom: 0px;
 	font-size: 26px;
 	text-transform: capitalize;
+}
+
+.year-count {
+	color: var(--color-main);
+	text-transform: initial;
+}
+
+.equal-sign {
+	padding: 0px 5px;
 }
 
 .data-highlight {

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -131,9 +131,10 @@
       "record": "Udsendelse"
    },
    "timeSearch": {
-      "timeMachine":"Søg via periode",
-     "searchDate": "Søg via dato",
-     "searchCategories": "Søg via kategori",
+      "timeMachine":"Udvælg en periode, som du gerne vil se indhold fra.",
+      "periodOf":"Periode på {number} år",
+      "searchDate": "Søg via dato",
+      "searchCategories": "Søg via kategori",
       "year":"år | år",
       "month":"måned | måneder",
       "week":"uge | uger",
@@ -157,7 +158,6 @@
       "allTimeslots":"Hele døgnet",
       "selection":"Et udpluk af resultaterne",
      "dateSubtitle": "Her kan du vælge en bestemt dato og se, hvad der blev sendt den dag.",
-     "timeMachineSubtitle": "Her kan du vælge årstal, hvis du søger udsendelser sendt i en bestemt periode. Når du klikker dig videre til resultatlisten, får du flere filtreringsmuligheder.",
      "searchCategoriesSubtitle": "Vælg en kategori og gå på opdagelse i udsendelserne. Kategorierne indeholder primært TV-udsendelser, mens du finder de fleste af radioudsendelserne i “Radio-rodekassen.”",
       "monthHeadline":"Vælg måneder",
       "dayHeadline":"Vælg ugedage",

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -131,7 +131,7 @@
       "record": "Udsendelse"
    },
    "timeSearch": {
-      "timeMachine":"Udvælg en periode, som du gerne vil se indhold fra.",
+      "timeMachine":"Udvælg en periode, som du gerne vil se indhold fra",
       "periodOf":"Periode på {number} år",
       "searchDate": "Søg via dato",
       "searchCategories": "Søg via kategori",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -131,7 +131,8 @@
       "record": "Programme"
    },
    "timeSearch": {
-      "timeMachine":"Search by period",
+      "timeMachine":"Select a period that you would like to view content from.",
+      "periodOf":"Period of {number} years | Priod of {number} year",
       "searchDate": "Search by date",
       "searchCategories": "Search by category",
       "year":"year | years",
@@ -157,7 +158,6 @@
       "allTimeslots":"All hours",
       "selection":"A selection of the results",
       "dateSubtitle": "Here you can select a specific date and see what was aired that day.",
-      "timeMachineSubtitle": "Here you can select years, if you are looking for programmes from a specific period in time. When you click through to the list of results, you will get more filtering options.",
       "searchCategoriesSubtitle": "Select a category and explore the programmes. The categories primarily contain TV programmes, while you will find most of the radio programmes in the “Radio jumble box.”",
       "monthHeadline":"Select months",
       "dayHeadline":"Select days of the week",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -131,7 +131,7 @@
       "record": "Programme"
    },
    "timeSearch": {
-      "timeMachine":"Select a period that you would like to view content from.",
+      "timeMachine":"Select a period that you would like to view content from",
       "periodOf":"Period of {number} years | Priod of {number} year",
       "searchDate": "Search by date",
       "searchCategories": "Search by category",


### PR DESCRIPTION
Did some tinkering to get closer to the design.

- Added transparent success border color to elements.css
- Updated h1 and h2 font styles in font-styles.css
- Refactored progress bar implementation in AdvancedSpot.vue
- Removed subtitle from TimeSearchComponent in PortalContent.vue
- Improved layout and styling in SimpleSpot.vue and SpotContainer.vue
- Changed heading from h3 to h1 in SpotCategories.vue
- Added year count display in TimeSearchFilters.vue
- Updated Danish and English localization for time search feature